### PR TITLE
Added support for android tv launcher

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -21,6 +21,7 @@
     <application
         android:name="paulscode.android.mupen64plusae.AppMupen64Plus"
         android:allowBackup="true"
+        android:isGame="true"
         android:hardwareAccelerated="true"
         android:icon="@drawable/icon"
         android:label="@string/app_name"
@@ -31,7 +32,7 @@
             android:theme="@style/appTheme.Black" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
                 <category android:name="android.intent.category.LAUNCHER" />
                 <category android:name="tv.ouya.intent.category.GAME" />
             </intent-filter>


### PR DESCRIPTION
Android TV has a separate launcher. This fix will allow you to show Mupen64plus on the launcher and in the "games" section
