### PR TITLE
Fixed auto-hold for touchscreen controls

### DIFF
--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -265,7 +265,7 @@ public class GamePrefs
         if( isTouchscreenEnabled )
         {
             touchscreenAutoHoldables = getSafeIntSet( touchscreenProfile,
-                    "touchscreenAutoHoldables" );
+                    "touchscreenAutoholdables" );
             
             String layout = touchscreenProfile.get( "touchscreenLayout", "" );
             if( layout.equals( "Custom" ) )


### PR DESCRIPTION
The auto-hold values were loaded using the wrong tag name when it came time to play the game, so auto-hold never worked. This just fixes the tag name.