### PR TITLE
Drag and drop editing for the touchscreen controls

### DIFF
--- a/src/paulscode/android/mupen64plusae/input/map/TouchMap.java
+++ b/src/paulscode/android/mupen64plusae/input/map/TouchMap.java
@@ -282,12 +282,8 @@ public class TouchMap
     {
         for( int i = 0; i < buttonNames.size(); i++ )
         {
-            String name = buttonNames.get( i );
-            if ( name.equals( assetName ) )
-            {
-                Image mask = buttonMasks.get( i );
-                return new Rect( mask.x, mask.y, mask.x + (int) ( mask.width * mask.scale ), mask.y + (int) ( mask.height * mask.scale ));
-            }
+            if ( buttonNames.get( i ).equals( assetName ) )
+                return new Rect( buttonMasks.get( i ).drawRect );
         }
         return new Rect(0, 0, 0, 0);
     }
@@ -360,10 +356,9 @@ public class TouchMap
      */
     public Rect getAnalogFrame()
     {
-        if( analogBackImage == null )
-            return new Rect(0, 0, 0, 0);
-        
-        return new Rect( analogBackImage.x, analogBackImage.y, analogBackImage.x + (int) ( analogBackImage.width * analogBackImage.scale ), analogBackImage.y + (int) ( analogBackImage.height * analogBackImage.scale ) );
+        if( analogBackImage != null )
+            return new Rect( analogBackImage.drawRect );
+        return new Rect(0, 0, 0, 0);
     }
     
     /**

--- a/src/paulscode/android/mupen64plusae/input/map/TouchMap.java
+++ b/src/paulscode/android/mupen64plusae/input/map/TouchMap.java
@@ -32,6 +32,7 @@ import paulscode.android.mupen64plusae.util.Image;
 import paulscode.android.mupen64plusae.util.Utility;
 import android.content.res.Resources;
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.util.FloatMath;
 import android.util.Log;
 import android.util.SparseArray;
@@ -82,6 +83,9 @@ public class TouchMap
     
     /** Y-coordinates of the buttons, in percent. */
     private final ArrayList<Integer> buttonY;
+    
+    /** names of the buttons. */
+    private final ArrayList<String> buttonNames;
     
     /** Analog background image (fixed). */
     protected Image analogBackImage;
@@ -177,6 +181,7 @@ public class TouchMap
         buttonMasks = new ArrayList<Image>();
         buttonX = new ArrayList<Integer>();
         buttonY = new ArrayList<Integer>();
+        buttonNames = new ArrayList<String>();
     }
     
     /**
@@ -188,6 +193,7 @@ public class TouchMap
         buttonMasks.clear();
         buttonX.clear();
         buttonY.clear();
+        buttonNames.clear();
         analogBackImage = null;
         analogForeImage = null;
         analogBackX = analogBackY = 0;
@@ -265,6 +271,28 @@ public class TouchMap
     }
     
     /**
+     * Gets the frame for the N64 button with a given asset name
+     * 
+     * @param assetName The asset name for the button
+     * 
+     * @return The frame for the N64 button with the given asset name
+     * 
+     */
+    public Rect getButtonFrame( String assetName )
+    {
+        for( int i = 0; i < buttonNames.size(); i++ )
+        {
+            String name = buttonNames.get( i );
+            if ( name.equals( assetName ) )
+            {
+                Image mask = buttonMasks.get( i );
+                return new Rect( mask.x, mask.y, mask.x + (int) ( mask.width * mask.scale ), mask.y + (int) ( mask.height * mask.scale ));
+            }
+        }
+        return new Rect(0, 0, 0, 0);
+    }
+    
+    /**
      * Gets the N64 button mapped to a given mask color.
      * 
      * @param color The mask color.
@@ -323,6 +351,19 @@ public class TouchMap
         int dY = yLocation - ( analogBackImage.y + (int) ( analogBackImage.hHeight * scale ) );
         
         return new Point( dX, dY );
+    }
+    
+    /**
+     * Gets the N64 analog stick's frame.
+     * 
+     * @return The analog stick's frame.
+     */
+    public Rect getAnalogFrame()
+    {
+        if( analogBackImage == null )
+            return new Rect(0, 0, 0, 0);
+        
+        return new Rect( analogBackImage.x, analogBackImage.y, analogBackImage.x + (int) ( analogBackImage.width * analogBackImage.scale ), analogBackImage.y + (int) ( analogBackImage.height * analogBackImage.scale ) );
     }
     
     /**
@@ -506,6 +547,7 @@ public class TouchMap
             // Position (percentages of the digitizer dimensions)
             buttonX.add( x );
             buttonY.add( y );
+            buttonNames.add( name );
             
             // Load the displayed and mask images
             buttonImages.add( new Image( mResources, skinFolder + "/" + name + ".png" ) );

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -413,7 +413,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 // unfortunately KitKat lacks a way to do this on its own,
                 // so just ignore all touches along the edges.
                 View view = getWindow().getDecorView();
-                if (y < 10 || y > view.getHeight() - 10 || x < 10 || x > view.getWidth() - 10)
+                if ( y < 10 || y > view.getHeight() - 10 || x < 10 || x > view.getWidth() - 10 )
                     return false;
             }
             
@@ -446,36 +446,36 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
         }
         else if( ( event.getAction() & MotionEvent.ACTION_MASK ) == MotionEvent.ACTION_MOVE )
         {
-            if (dragIndex != TouchMap.UNMAPPED || ANALOG.equals(dragAsset))
+            if ( dragIndex != TouchMap.UNMAPPED || ANALOG.equals(dragAsset) )
             {
-                if (!dragging)
+                if ( !dragging )
                 {
                     int dX = x - initialX;
                     int dY = y - initialY;
                     float displacement = FloatMath.sqrt( ( dX * dX ) + ( dY * dY ) );
-                    if (displacement >= 10)
+                    if ( displacement >= 10 )
                         dragging = true;
                 }
-                if (!dragging)
+                if ( !dragging )
                     return false;
                 
                 // drag this button or analog stick around
                 
                 // calculate the X and Y percentage
                 View view = getWindow().getDecorView();
-                int newDragX = (x - (initialX - dragFrame.left)) * 100/(view.getWidth() - (dragFrame.right - dragFrame.left));
-                int newDragY = (y - (initialY - dragFrame.top)) * 100/(view.getHeight() - (dragFrame.bottom - dragFrame.top));
+                int newDragX = ( x - ( initialX - dragFrame.left ) ) * 100/( view.getWidth() - ( dragFrame.right - dragFrame.left ) );
+                int newDragY = ( y - ( initialY - dragFrame.top ) ) * 100/( view.getHeight() - ( dragFrame.bottom - dragFrame.top ) );
                 
                 // round to the nearest 5%
-                newDragX = Math.min(Math.max(Math.round(newDragX / 5) * 5, 0), 100);
-                newDragY = Math.min(Math.max(Math.round(newDragY / 5) * 5, 0), 100);
+                newDragX = Math.min( Math.max( Math.round( newDragX / 5 ) * 5, 0 ), 100 );
+                newDragY = Math.min( Math.max( Math.round( newDragY / 5 ) * 5, 0 ), 100 );
                 
-                if (newDragX != dragX || newDragY != dragY)
+                if ( newDragX != dragX || newDragY != dragY )
                 {
                     dragX = newDragX;
                     dragY = newDragY;
-                    mProfile.put( dragAsset + TAG_X, String.valueOf(newDragX) );
-                    mProfile.put( dragAsset + TAG_Y, String.valueOf(newDragY) );
+                    mProfile.put( dragAsset + TAG_X, String.valueOf( newDragX ) );
+                    mProfile.put( dragAsset + TAG_Y, String.valueOf( newDragY ) );
                     refresh();
                 }
             }
@@ -483,15 +483,15 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
         else if( ( event.getAction() & MotionEvent.ACTION_MASK ) == MotionEvent.ACTION_UP )
         {
             // if this touch was part of a drag/swipe gesture then don't tap the button
-            if (dragging)
+            if ( dragging )
                 return false;
             
             // show the editor for the tapped button
-            if (ANALOG.equals(dragAsset))
+            if ( ANALOG.equals( dragAsset ) )
             {
                 // play the standard button sound effect
                 View view = getWindow().getDecorView();
-                view.playSoundEffect(SoundEffectConstants.CLICK);
+                view.playSoundEffect( SoundEffectConstants.CLICK );
                 
                 popupDialog( dragAsset, getString( R.string.controller_analog ), -1 );
             }
@@ -506,7 +506,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 
                 // play the standard button sound effect
                 View view = getWindow().getDecorView();
-                view.playSoundEffect(SoundEffectConstants.CLICK);
+                view.playSoundEffect( SoundEffectConstants.CLICK );
                 
                 popupDialog( dragAsset, title, index );
             }

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -434,7 +434,6 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 float displacement = FloatMath.sqrt( ( dX * dX ) + ( dY * dY ) );
                 if( mTouchscreenMap.isInCaptureRange( displacement ) )
                 {
-                    dragIndex = -2;
                     dragAsset = ANALOG;
                     dragFrame = mTouchscreenMap.getAnalogFrame();
                 }
@@ -447,7 +446,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
         }
         else if( ( event.getAction() & MotionEvent.ACTION_MASK ) == MotionEvent.ACTION_MOVE )
         {
-            if (dragIndex != TouchMap.UNMAPPED)
+            if (dragIndex != TouchMap.UNMAPPED || dragAsset.equals(ANALOG))
             {
                 if (!dragging)
                 {
@@ -488,7 +487,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 return false;
             
             // show the editor for the tapped button
-            if (dragIndex == -2)
+            if (dragAsset.equals(ANALOG))
             {
                 // play the standard button sound effect
                 View view = getWindow().getDecorView();

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -37,6 +37,7 @@ import paulscode.android.mupen64plusae.persistent.UserPrefs;
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
 import android.app.ActionBar;
+import android.app.ActionBar.OnMenuVisibilityListener;
 import android.app.Activity;
 import android.app.AlertDialog.Builder;
 import android.content.DialogInterface;
@@ -109,6 +110,9 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
     private int dragY;
     private Rect dragFrame;
     
+    // Don't enter immersive mode until the ActionBar menus are closed
+    private boolean actionBarMenuOpen = false;
+    
     @TargetApi( 11 )
     @Override
     protected void onCreate( Bundle savedInstanceState )
@@ -175,6 +179,18 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
             ColorDrawable color = new ColorDrawable( Color.parseColor( "#303030" ) );
             color.setAlpha( mUserPrefs.displayActionBarTransparency );
             getActionBar().setBackgroundDrawable( color );
+            
+            // onOptionsMenuClosed is not called due to a bug in Android:
+            // http://stackoverflow.com/questions/3688077/android-onoptionsmenuclosed-not-being-called-for-submenu
+            // so add a menu visibility listener instead
+            getActionBar().addOnMenuVisibilityListener( new OnMenuVisibilityListener()
+            {
+                @Override
+                public void onMenuVisibilityChanged( boolean isVisible )
+                {
+                    actionBarMenuOpen = isVisible;
+                }
+            });
         }
         
         // Initialize the touchmap and overlay
@@ -218,7 +234,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
     public void onWindowFocusChanged( boolean hasFocus )
     {
         super.onWindowFocusChanged( hasFocus );
-        if( hasFocus )
+        if( hasFocus && !actionBarMenuOpen )
             hideSystemBars();
     }
     

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -446,7 +446,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
         }
         else if( ( event.getAction() & MotionEvent.ACTION_MASK ) == MotionEvent.ACTION_MOVE )
         {
-            if (dragIndex != TouchMap.UNMAPPED || dragAsset.equals(ANALOG))
+            if (dragIndex != TouchMap.UNMAPPED || ANALOG.equals(dragAsset))
             {
                 if (!dragging)
                 {
@@ -487,7 +487,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 return false;
             
             // show the editor for the tapped button
-            if (dragAsset.equals(ANALOG))
+            if (ANALOG.equals(dragAsset))
             {
                 // play the standard button sound effect
                 View view = getWindow().getDecorView();

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -407,10 +407,15 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
             dragIndex = TouchMap.UNMAPPED;
             dragging = false;
             
-            // ignore touches that start at the very bottom or top of the screen
-            View view = getWindow().getDecorView();
-            if (y < 10 || y > view.getHeight() - 10)
-                return false;
+            if( AppData.IS_KITKAT && mUserPrefs.isImmersiveModeEnabled )
+            {
+                // ignore edge swipes.
+                // unfortunately KitKat lacks a way to do this on its own,
+                // so just ignore all touches along the edges.
+                View view = getWindow().getDecorView();
+                if (y < 10 || y > view.getHeight() - 10 || x < 10 || x > view.getWidth() - 10)
+                    return false;
+            }
             
             // Get the N64 index of the button that was pressed
             int index = mTouchscreenMap.getButtonPress( x, y );

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -406,6 +406,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
             initialY = y;
             dragIndex = TouchMap.UNMAPPED;
             dragging = false;
+            dragAsset = "";
             
             if( AppData.IS_KITKAT && mUserPrefs.isImmersiveModeEnabled )
             {

--- a/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/TouchscreenProfileActivity.java
@@ -413,6 +413,7 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 // ignore edge swipes.
                 // unfortunately KitKat lacks a way to do this on its own,
                 // so just ignore all touches along the edges.
+                // http://stackoverflow.com/questions/20530333/ignore-immersive-mode-swipe
                 View view = getWindow().getDecorView();
                 if ( y < 10 || y > view.getHeight() - 10 || x < 10 || x > view.getWidth() - 10 )
                     return false;
@@ -467,9 +468,8 @@ public class TouchscreenProfileActivity extends Activity implements OnTouchListe
                 int newDragX = ( x - ( initialX - dragFrame.left ) ) * 100/( view.getWidth() - ( dragFrame.right - dragFrame.left ) );
                 int newDragY = ( y - ( initialY - dragFrame.top ) ) * 100/( view.getHeight() - ( dragFrame.bottom - dragFrame.top ) );
                 
-                // round to the nearest 5%
-                newDragX = Math.min( Math.max( Math.round( newDragX / 5 ) * 5, 0 ), 100 );
-                newDragY = Math.min( Math.max( Math.round( newDragY / 5 ) * 5, 0 ), 100 );
+                newDragX = Math.min( Math.max( newDragX, 0 ), 100 );
+                newDragY = Math.min( Math.max( newDragY, 0 ), 100 );
                 
                 if ( newDragX != dragX || newDragY != dragY )
                 {


### PR DESCRIPTION
Things that are changed with this commit:

- added drag and drop editing for the on-screen controller layout.
Right now the values are clamped to the nearest 5% to match the
behavior of the edit dialog, although I feel like we should allow any %
for that.
- tapping on a button plays the standard button sound effect, as I felt
that was missing.
- made it possible to swipe from the top or bottom of the screen to
show the back/home/menu buttons or status bar without *also* triggering
the edit dialog for a button that was under your finger, since that
dialog prevented the user from being able to use the menus at the top
of the screen.