### PR TITLE
Directory selection activity fixes

### DIFF
--- a/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
+++ b/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
@@ -169,6 +169,9 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
         AppData appData, GlobalPrefs globalPrefs )
     {
         this.mStartDir = startDir;
+        this.mSearchZips = searchZips;
+        this.mDownloadArt = downloadArt;
+        this.mClearGallery = clearGallery;
         this.mAppData = appData;
         this.mGlobalPrefs = globalPrefs;
         

--- a/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
+++ b/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
@@ -242,7 +242,7 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
         }
         
         // This entry appears to be a valid ROM, extract it
-        Log.i( "GalleryActivity", "Found zip entry " + zipEntry.getName() );
+        Log.i( "CacheRomInfoFragment", "Found zip entry " + zipEntry.getName() );
 
         String entryName = new File( zipEntry.getName() ).getName();
         File extractedFile = new File( destDir, entryName );

--- a/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
+++ b/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
@@ -46,7 +46,7 @@ import android.os.Bundle;
 import android.os.IBinder;
 
 public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListener
-{
+{    
     //Progress dialog for ROM scan
     private ProgressDialog mProgress = null;
     
@@ -113,7 +113,7 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
 
     @Override
     public void onAttach(Activity activity)
-    {
+    {        
         super.onAttach(activity);
     }
     
@@ -127,6 +127,17 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
         }
         
         super.onDetach();
+    }
+    
+    @Override
+    public void onDestroy()
+    {        
+        if(mServiceConnection != null)
+        {
+            ActivityHelper.stopCacheRomInfoService(getActivity().getApplicationContext(), mServiceConnection);
+        }
+        
+        super.onDestroy();
     }
 
     @Override

--- a/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
+++ b/src/paulscode/android/mupen64plusae/CacheRomInfoFragment.java
@@ -64,16 +64,11 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
     private boolean mCachedScanFinish = false;
     
     private File mStartDir = null;
+    private boolean mSearchZips = false;
+    private boolean mDownloadArt = false;
+    private boolean mClearGallery = false;
     
     private boolean mInProgress = false;
-    
-    public CacheRomInfoFragment(AppData appData, GlobalPrefs globalPrefs)
-    {
-        super();
-
-        this.mAppData = appData;
-        this.mGlobalPrefs = globalPrefs;
-    }
 
     // this method is only called once for this fragment
     @Override
@@ -170,9 +165,12 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
         return mProgress;
     }
 
-    public void refreshRoms( File startDir )
+    public void refreshRoms( File startDir, boolean searchZips, boolean downloadArt, boolean clearGallery,
+        AppData appData, GlobalPrefs globalPrefs )
     {
         this.mStartDir = startDir;
+        this.mAppData = appData;
+        this.mGlobalPrefs = globalPrefs;
         
         if(getActivity() != null)
         {
@@ -215,8 +213,8 @@ public class CacheRomInfoFragment extends Fragment implements CacheRomInfoListen
         // Asynchronously search for ROMs
         ActivityHelper.startCacheRomInfoService(activity.getApplicationContext(), mServiceConnection,
             mStartDir.getAbsolutePath(), mAppData.mupen64plus_ini, mGlobalPrefs.romInfoCache_cfg,
-            mGlobalPrefs.coverArtDir, mGlobalPrefs.unzippedRomsDir, mGlobalPrefs.getSearchZips(),
-            mGlobalPrefs.getDownloadArt(), mGlobalPrefs.getClearGallery());
+            mGlobalPrefs.coverArtDir, mGlobalPrefs.unzippedRomsDir, mSearchZips,
+            mDownloadArt, mClearGallery);
     }
     
     public boolean IsInProgress()

--- a/src/paulscode/android/mupen64plusae/GalleryActivity.java
+++ b/src/paulscode/android/mupen64plusae/GalleryActivity.java
@@ -303,7 +303,7 @@ public class GalleryActivity extends AppCompatActivity
         
         if(mCacheRomInfoFragment == null)
         {
-            mCacheRomInfoFragment = new CacheRomInfoFragment(mAppData, mGlobalPrefs);
+            mCacheRomInfoFragment = new CacheRomInfoFragment();
             fm.beginTransaction().add(mCacheRomInfoFragment, STATE_CACHE_ROM_INFO_FRAGMENT).commit();
         }
     }
@@ -583,18 +583,21 @@ public class GalleryActivity extends AppCompatActivity
             {
                 Bundle extras = data.getExtras();
                 String searchPath = extras.getString( ActivityHelper.Keys.SEARCH_PATH );
+                boolean searchZips = extras.getBoolean( ActivityHelper.Keys.SEARCH_ZIPS );
+                boolean downloadArt = extras.getBoolean( ActivityHelper.Keys.DOWNLOAD_ART );
+                boolean clearGallery = extras.getBoolean( ActivityHelper.Keys.CLEAR_GALLERY );
                 
                 if (searchPath != null)
                 {
-                    refreshRoms(new File(searchPath));
+                    refreshRoms(new File(searchPath), searchZips, downloadArt, clearGallery);
                 }
             }
         }
     }
     
-    private void refreshRoms( final File startDir )
+    private void refreshRoms( final File startDir, boolean searchZips, boolean downloadArt, boolean clearGallery )
     {
-        mCacheRomInfoFragment.refreshRoms(startDir);
+        mCacheRomInfoFragment.refreshRoms(startDir, searchZips, downloadArt, clearGallery, mAppData, mGlobalPrefs);
     }
 
     void refreshGrid( ){

--- a/src/paulscode/android/mupen64plusae/ScanRomsActivity.java
+++ b/src/paulscode/android/mupen64plusae/ScanRomsActivity.java
@@ -77,6 +77,9 @@ public class ScanRomsActivity extends AppCompatActivity implements OnItemClickLi
             public void onClick(View v) {
                 Intent data = new Intent();
                 data.putExtra(ActivityHelper.Keys.SEARCH_PATH, mCurrentPath.getPath());
+                data.putExtra(ActivityHelper.Keys.SEARCH_ZIPS, mCheckBox1.isChecked());
+                data.putExtra(ActivityHelper.Keys.DOWNLOAD_ART, mCheckBox2.isChecked());
+                data.putExtra(ActivityHelper.Keys.CLEAR_GALLERY, mCheckBox3.isChecked());
                 ScanRomsActivity.this.setResult(RESULT_OK, data);
                 ScanRomsActivity.this.finish();
             }

--- a/src/paulscode/android/mupen64plusae/persistent/GlobalPrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GlobalPrefs.java
@@ -236,9 +236,6 @@ public class GlobalPrefs
     private static final String KEYTEMPLATE_PAK_TYPE = "inputPakType%1$d";
     private static final String KEY_PLAYER_MAP_REMINDER = "playerMapReminder";
     private static final String KEY_LOCALE_OVERRIDE = "localeOverride";
-    private static final String KEY_SEARCH_ZIPS = "searchZips";
-    private static final String KEY_DOWNLOAD_ART = "downloadArt";
-    private static final String KEY_CLEAR_GALLERY = "clearGallery";
     // ... add more as needed
     
     // Shared preferences default values
@@ -586,21 +583,6 @@ public class GlobalPrefs
         return getBoolean( KEY_PLAYER_MAP_REMINDER, DEFAULT_PLAYER_MAP_REMINDER );
     }
     
-    public boolean getSearchZips()
-    {
-        return getBoolean( KEY_SEARCH_ZIPS, DEFAULT_SEARCH_ZIPS );
-    }
-    
-    public boolean getDownloadArt()
-    {
-        return getBoolean( KEY_DOWNLOAD_ART, DEFAULT_DOWNLOAD_ART );
-    }
-    
-    public boolean getClearGallery()
-    {
-        return getBoolean( KEY_CLEAR_GALLERY, DEFAULT_CLEAR_GALLERY );
-    }
-    
     public void putEmulationProfileDefault( String value )
     {
         putString( KEY_EMULATION_PROFILE_DEFAULT, value );
@@ -624,21 +606,6 @@ public class GlobalPrefs
     public void putPlayerMapReminder( boolean value )
     {
         putBoolean( KEY_PLAYER_MAP_REMINDER, value );
-    }
-    
-    public void putSearchZips( boolean value )
-    {
-        putBoolean( KEY_SEARCH_ZIPS, value );
-    }
-    
-    public void putDownloadArt( boolean value )
-    {
-        putBoolean( KEY_DOWNLOAD_ART, value );
-    }
-    
-    public void putClearGallery( boolean value )
-    {
-        putBoolean( KEY_CLEAR_GALLERY, value );
     }
     
     private boolean getBoolean( String key, boolean defaultValue )

--- a/src/paulscode/android/mupen64plusae/task/CacheRomInfoService.java
+++ b/src/paulscode/android/mupen64plusae/task/CacheRomInfoService.java
@@ -159,7 +159,7 @@ public class CacheRomInfoService extends Service
                 }
                 else if( header.isZip && mSearchZips )
                 {
-                    Log.i( "CacheRomInfoTask", "Found zip file " + file.getName() );
+                    Log.i( "CacheRomInfoService", "Found zip file " + file.getName() );
                     try
                     {
                         ZipFile zipFile = new ZipFile( file );
@@ -189,7 +189,7 @@ public class CacheRomInfoService extends Service
                             }
                             catch( IOException e )
                             {
-                                Log.w( "CacheRomInfoTask", e );
+                                Log.w( "CacheRomInfoService", e );
                             }
                             mListener.GetProgressDialog().incrementSubprogress( 1 );
                         }
@@ -197,15 +197,15 @@ public class CacheRomInfoService extends Service
                     }
                     catch( ZipException e )
                     {
-                        Log.w( "CacheRomInfoTask", e );
+                        Log.w( "CacheRomInfoService", e );
                     }
                     catch( IOException e )
                     {
-                        Log.w( "CacheRomInfoTask", e );
+                        Log.w( "CacheRomInfoService", e );
                     }
                     catch( ArrayIndexOutOfBoundsException e )
                     {
-                        Log.w( "CacheRomInfoTask", e );
+                        Log.w( "CacheRomInfoService", e );
                     }
                 }
                 mListener.GetProgressDialog().incrementProgress( 1 );
@@ -316,7 +316,9 @@ public class CacheRomInfoService extends Service
         {
             if( mbStopped ) return;
             mListener.GetProgressDialog().setMessage( R.string.cacheRomInfo_downloadingArt );
+            Log.i( "CacheRomInfoService", "Start art download: " +  artPath);
             downloadFile( detail.artUrl, artPath );
+            Log.i( "CacheRomInfoService", "End art download: " +  artPath);
         }
         
         if( mbStopped ) return;
@@ -334,13 +336,13 @@ public class CacheRomInfoService extends Service
             }
             catch( IOException e )
             {
-                Log.w( "CacheRomInfoTask", e );
+                Log.w( "CacheRomInfoService", e );
                 return e;
             }
         }
         catch( FileNotFoundException e )
         {
-            Log.w( "CacheRomInfoTask", e );
+            Log.w( "CacheRomInfoService", e );
             return e;
         }
         return null;
@@ -378,7 +380,7 @@ public class CacheRomInfoService extends Service
         }
         catch( Throwable e )
         {
-            Log.w( "CacheRomInfoTask", e );
+            Log.w( "CacheRomInfoService", e );
             return e;
         }
         finally
@@ -391,7 +393,7 @@ public class CacheRomInfoService extends Service
                 }
                 catch( IOException e )
                 {
-                    Log.w( "CacheRomInfoTask", e );
+                    Log.w( "CacheRomInfoService", e );
                 }
             if( inStream != null )
                 try
@@ -400,7 +402,7 @@ public class CacheRomInfoService extends Service
                 }
                 catch( IOException e )
                 {
-                    Log.w( "CacheRomInfoTask", e );
+                    Log.w( "CacheRomInfoService", e );
                 }
         }
     }

--- a/src/paulscode/android/mupen64plusae/util/RomDatabase.java
+++ b/src/paulscode/android/mupen64plusae/util/RomDatabase.java
@@ -204,7 +204,7 @@ public class RomDatabase
                 baseName = goodName.split( " \\(" )[0].trim();
                 
                 // Generate the cover art URL string
-                artName = baseName.replaceAll( "['\\.]", "" ).replaceAll( "\\W+", "_" ) + ".png";
+                artName = baseName.replaceAll( "['\\.!]", "" ).replaceAll( "\\W+", "_" ) + ".png";
                 artUrl = String.format( ART_URL_TEMPLATE, artName );
                 
                 // Generate wiki page URL string


### PR DESCRIPTION
Fixed crash if application is killed by os while the ScanRomActivity is active.
Fixed issue that could cause the service notification icon to remain if the application was killed by the OS.
Fixed issue that prevented some gallery cover art from downloading correctly.
Fixed issue with scan config parameters not being passed on to the scan service.