### PR TITLE
Removed unneeded general options

### DIFF
--- a/res/xml/preferences_global.xml
+++ b/res/xml/preferences_global.xml
@@ -61,21 +61,6 @@
             android:key="showFullNames"
             android:summary="@string/showFullNames_summary"
             android:title="@string/showFullNames_title" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="searchZips"
-            android:title="@string/scanRomsDialog_searchZips" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="downloadArt"
-            android:title="@string/scanRomsDialog_downloadArt" />
-
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="clearGallery"
-            android:title="@string/scanRomsDialog_clearGallery" />
     </PreferenceCategory>
 
     <PreferenceCategory


### PR DESCRIPTION
Removed these general options: search zips, download art, and clear gallery. They are now set on the directory selection activity before each ROM scan.