### PR TITLE
Fix GalleryActivity jerkyness by loading bitmaps in a background task.

### DIFF
--- a/src/paulscode/android/mupen64plusae/GalleryItem.java
+++ b/src/paulscode/android/mupen64plusae/GalleryItem.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 import org.mupen64plusae.v3.alpha.R;
 
+import paulscode.android.mupen64plusae.task.LoadBitmapTask;
 import android.content.Context;
 import android.graphics.drawable.BitmapDrawable;
 import android.support.v7.widget.RecyclerView;
@@ -220,10 +221,6 @@ public class GalleryItem
             if( item != null )
             {
                 ImageView artView = (ImageView) view.findViewById( R.id.imageArt );
-                if( item.artBitmap != null )
-                    artView.setImageDrawable( item.artBitmap );
-                else
-                    artView.setImageResource( R.drawable.default_coverart );
                 
                 TextView tv1 = (TextView) view.findViewById( R.id.text1 );
                 tv1.setText( item.toString() );
@@ -251,11 +248,11 @@ public class GalleryItem
                     tv1.setTextSize( TypedValue.COMPLEX_UNIT_DIP, 13.0f );
                     artView.setVisibility( View.VISIBLE );
                     
-                    item.loadBitmap();
-                    if( item.artBitmap != null )
-                        artView.setImageDrawable( item.artBitmap );
-                    else
-                        artView.setImageResource( R.drawable.default_coverart );
+                    artView.setImageResource( R.drawable.default_coverart );
+
+                    //Load the real cover art in a background task
+                    LoadBitmapTask loadBitmapTask = new LoadBitmapTask(item.context, item.artPath, artView); 
+                    loadBitmapTask.execute((String) null);
                     
                     artView.getLayoutParams().width = activity.galleryWidth;
                     artView.getLayoutParams().height = (int) ( activity.galleryWidth / activity.galleryAspectRatio );

--- a/src/paulscode/android/mupen64plusae/task/LoadBitmapTask.java
+++ b/src/paulscode/android/mupen64plusae/task/LoadBitmapTask.java
@@ -1,0 +1,68 @@
+/**
+ * Mupen64PlusAE, an N64 emulator for the Android platform
+ * 
+ * Copyright (C) 2015 Paul Lamb
+ * 
+ * This file is part of Mupen64PlusAE.
+ * 
+ * Mupen64PlusAE is free software: you can redistribute it and/or modify it under the terms of the
+ * GNU General Public License as published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ * 
+ * Mupen64PlusAE is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+ * without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License along with Mupen64PlusAE. If
+ * not, see <http://www.gnu.org/licenses/>.
+ * 
+ * Authors: fzurita
+ */
+package paulscode.android.mupen64plusae.task;
+
+import java.io.File;
+
+import org.mupen64plusae.v3.alpha.R;
+
+import android.content.Context;
+import android.graphics.drawable.BitmapDrawable;
+import android.os.AsyncTask;
+import android.text.TextUtils;
+import android.widget.ImageView;
+
+public class LoadBitmapTask extends AsyncTask<String, String, String>
+{
+    
+    private final String mBitmapPath;
+    private final ImageView mArtView;
+    private BitmapDrawable mArtBitmap;
+    public final Context mContext;
+    
+    public LoadBitmapTask( Context context, String bitmapPath, ImageView artView)
+    {
+        mBitmapPath = bitmapPath;
+        mArtView = artView;
+        mArtBitmap = null;
+        mContext = context;
+    }
+
+    @Override
+    protected String doInBackground(String... params)
+    {
+        if( !TextUtils.isEmpty( mBitmapPath ) && new File( mBitmapPath ).exists() )
+        {
+            mArtBitmap = new BitmapDrawable( mContext.getResources(), mBitmapPath );
+        }
+        return null;
+    }
+    
+    @Override
+    protected void onPostExecute( String result )
+    {
+        if( mArtBitmap != null )
+            mArtView.setImageDrawable( mArtBitmap );
+        else
+            mArtView.setImageResource( R.drawable.default_coverart );
+    }
+
+}


### PR DESCRIPTION
This fixes gallery jerkyness.