### PR TITLE
Fixed crash when loading unknown profile

### DIFF
--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -409,6 +409,8 @@ public class GamePrefs
             return null;
         else if( custom.keySet().contains( name ) )
             return new Profile( false, custom.get( name ) );
+        else if( custom.keySet().contains( defaultName ) )
+            return new Profile( false, custom.get( defaultName ) );
         else if( builtin.keySet().contains( name ) )
             return new Profile( true, builtin.get( name ) );
         else if( builtin.keySet().contains( defaultName ) )


### PR DESCRIPTION
Fixed issue where if a game's configured profile doesn't exist in the list of user profiles, the app would crash.