### PR TITLE
Additional profile fixes

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -400,7 +400,7 @@
     <string name="controllerProfile2_title">Controller 2 profile</string>
     <string name="controllerProfile3_title">Controller 3 profile</string>
     <string name="controllerProfile4_title">Controller 4 profile</string>
-    <string name="default_profile_title">Current Default</string>
+    <string name="default_profile_title">Global Default</string>
     
     <!-- Other Preferences -->
     <string name="GameAutoSavesMax_title">Max auto saves per game</string>

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -185,6 +185,16 @@ public class GamePrefs
     
     private final SharedPreferences mPreferences;
     
+    /** Profile keys */
+    public static final String EMULATION_PROFILE = "emulationProfile";
+    public static final String TOUCHSCREEN_PROFILE = "touchscreenProfile";
+    public static final String CONTROLLER_PROFILE1 = "controllerProfile1";
+    public static final String CONTROLLER_PROFILE2 = "controllerProfile2";
+    public static final String CONTROLLER_PROFILE3 = "controllerProfile3";
+    public static final String CONTROLLER_PROFILE4 = "controllerProfile4";
+    public static final String PLAYER_MAP = "playerMap";
+    public static final String PLAY_SHOW_CHEATS = "playShowCheats";
+    
     public GamePrefs( Context context, String romMd5, String crc, String headerName, String countrySymbol,
         AppData appData, GlobalPrefs globalPrefs)
     {        
@@ -202,34 +212,34 @@ public class GamePrefs
         mupen64plus_cfg = coreUserConfigDir + "/mupen64plus.cfg";
         
         // Emulation profile
-        emulationProfile = loadProfile( mPreferences, "emulationProfile",
+        emulationProfile = loadProfile( mPreferences, EMULATION_PROFILE,
                 globalPrefs.getEmulationProfileDefault(),
                 globalPrefs.GetEmulationProfilesConfig(), appData.GetEmulationProfilesConfig() );
         
         // Touchscreen profile
-        touchscreenProfile = loadProfile( mPreferences, "touchscreenProfile",
+        touchscreenProfile = loadProfile( mPreferences, TOUCHSCREEN_PROFILE,
                 globalPrefs.getTouchscreenProfileDefault(),
                 globalPrefs.GetTouchscreenProfilesConfig(), appData.GetTouchscreenProfilesConfig() );
         
         // Controller profiles
-        controllerProfile1 = loadControllerProfile( mPreferences, "controllerProfile1",
+        controllerProfile1 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE1,
                 globalPrefs.getControllerProfileDefault(),
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile2 = loadControllerProfile( mPreferences, "controllerProfile2",
+        controllerProfile2 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE2,
                 "",
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile3 = loadControllerProfile( mPreferences, "controllerProfile3",
+        controllerProfile3 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE3,
                 "",
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile4 = loadControllerProfile( mPreferences, "controllerProfile4",
+        controllerProfile4 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE4,
                 "",
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
         
         // Player map
-        playerMap = new PlayerMap( mPreferences.getString( "playerMap", "" ) );
+        playerMap = new PlayerMap( mPreferences.getString( PLAYER_MAP, "" ) );
         
         // Cheats menu
-        isCheatOptionsShown = mPreferences.getBoolean( "playShowCheats", false );
+        isCheatOptionsShown = mPreferences.getBoolean( PLAY_SHOW_CHEATS, false );
         
         // Emulation prefs
         r4300Emulator = emulationProfile.get( "r4300Emulator", "2" );

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -421,6 +421,8 @@ public class GamePrefs
             return new ControllerProfile( false, custom.get( name ) );
         else if( builtin.keySet().contains( name ) )
             return new ControllerProfile( true, builtin.get( name ) );
+        if( custom.keySet().contains( name ) )
+            return new ControllerProfile( false, custom.get( defaultName ) );
         else if( builtin.keySet().contains( defaultName ) )
             return new ControllerProfile( true, builtin.get( defaultName ) );
         else

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -421,7 +421,7 @@ public class GamePrefs
             return new ControllerProfile( false, custom.get( name ) );
         else if( builtin.keySet().contains( name ) )
             return new ControllerProfile( true, builtin.get( name ) );
-        if( custom.keySet().contains( name ) )
+        else if( custom.keySet().contains( defaultName ) )
             return new ControllerProfile( false, custom.get( defaultName ) );
         else if( builtin.keySet().contains( defaultName ) )
             return new ControllerProfile( true, builtin.get( defaultName ) );

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
@@ -264,6 +264,13 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
         mControllerProfile4.populateProfiles( mAppData.GetControllerProfilesConfig(),
                 mGlobalPrefs.GetControllerProfilesConfig(), "" );
         
+        mEmulationProfile.setSummary(mEmulationProfile.getCurrentValue());
+        mTouchscreenProfile.setSummary(mTouchscreenProfile.getCurrentValue());
+        mControllerProfile1.setSummary(mControllerProfile1.getCurrentValue());
+        mControllerProfile2.setSummary(mControllerProfile2.getCurrentValue());
+        mControllerProfile3.setSummary(mControllerProfile3.getCurrentValue());
+        mControllerProfile4.setSummary(mControllerProfile4.getCurrentValue());
+        
         // Refresh the preferences objects in case populate* changed a value
         mGlobalPrefs = new GlobalPrefs( this, mAppData );
         mGamePrefs = new GamePrefs( this, mRomMd5, mRomCrc, mRomHeaderName, RomHeader.countryCodeToSymbol(mRomCountryCode),

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
@@ -66,15 +66,6 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
     private static final String ACTION_WIKI = "actionWiki";
     private static final String ACTION_RESET_GAME_PREFS = "actionResetGamePrefs";
     
-    private static final String EMULATION_PROFILE = "emulationProfile";
-    private static final String TOUCHSCREEN_PROFILE = "touchscreenProfile";
-    private static final String CONTROLLER_PROFILE1 = "controllerProfile1";
-    private static final String CONTROLLER_PROFILE2 = "controllerProfile2";
-    private static final String CONTROLLER_PROFILE3 = "controllerProfile3";
-    private static final String CONTROLLER_PROFILE4 = "controllerProfile4";
-    private static final String PLAYER_MAP = "playerMap";
-    private static final String PLAY_SHOW_CHEATS = "playShowCheats";
-    
     // App data and user preferences
     private AppData mAppData = null;
     private GlobalPrefs mGlobalPrefs = null;
@@ -150,12 +141,12 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
         // Load user preference menu structure from XML and update view
         getPreferenceManager().setSharedPreferencesName( mGamePrefs.sharedPrefsName );
         addPreferencesFromResource( R.xml.preferences_game );
-        mEmulationProfile = (ProfilePreference) findPreference( EMULATION_PROFILE );
-        mTouchscreenProfile = (ProfilePreference) findPreference( TOUCHSCREEN_PROFILE );
-        mControllerProfile1 = (ProfilePreference) findPreference( CONTROLLER_PROFILE1 );
-        mControllerProfile2 = (ProfilePreference) findPreference( CONTROLLER_PROFILE2 );
-        mControllerProfile3 = (ProfilePreference) findPreference( CONTROLLER_PROFILE3 );
-        mControllerProfile4 = (ProfilePreference) findPreference( CONTROLLER_PROFILE4 );
+        mEmulationProfile = (ProfilePreference) findPreference( GamePrefs.EMULATION_PROFILE );
+        mTouchscreenProfile = (ProfilePreference) findPreference( GamePrefs.TOUCHSCREEN_PROFILE );
+        mControllerProfile1 = (ProfilePreference) findPreference( GamePrefs.CONTROLLER_PROFILE1 );
+        mControllerProfile2 = (ProfilePreference) findPreference( GamePrefs.CONTROLLER_PROFILE2 );
+        mControllerProfile3 = (ProfilePreference) findPreference( GamePrefs.CONTROLLER_PROFILE3 );
+        mControllerProfile4 = (ProfilePreference) findPreference( GamePrefs.CONTROLLER_PROFILE4 );
         mScreenCheats = (PreferenceGroup) findPreference( SCREEN_CHEATS );
         mCategoryCheats = (PreferenceGroup) findPreference( CATEGORY_CHEATS );
         
@@ -177,24 +168,24 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
         if( mRomDetail.players == 1 )
         {
             // Simplify name of "controller 1" to just "controller" to eliminate confusion
-            findPreference( CONTROLLER_PROFILE1 ).setTitle( R.string.controllerProfile_title );
+            findPreference( GamePrefs.CONTROLLER_PROFILE1 ).setTitle( R.string.controllerProfile_title );
             
             // Remove unneeded preference items
-            PrefUtil.removePreference( this, SCREEN_ROOT, CONTROLLER_PROFILE2 );
-            PrefUtil.removePreference( this, SCREEN_ROOT, CONTROLLER_PROFILE3 );
-            PrefUtil.removePreference( this, SCREEN_ROOT, CONTROLLER_PROFILE4 );
-            PrefUtil.removePreference( this, SCREEN_ROOT, PLAYER_MAP );
+            PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.CONTROLLER_PROFILE2 );
+            PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.CONTROLLER_PROFILE3 );
+            PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.CONTROLLER_PROFILE4 );
+            PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.PLAYER_MAP );
         }
         else
         {
             // Remove unneeded preference items
             if( mRomDetail.players < 4 )
-                PrefUtil.removePreference( this, SCREEN_ROOT, CONTROLLER_PROFILE4 );
+                PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.CONTROLLER_PROFILE4 );
             if( mRomDetail.players < 3 )
-                PrefUtil.removePreference( this, SCREEN_ROOT, CONTROLLER_PROFILE3 );
+                PrefUtil.removePreference( this, SCREEN_ROOT, GamePrefs.CONTROLLER_PROFILE3 );
             
             // Configure the player map preference
-            PlayerMapPreference playerPref = (PlayerMapPreference) findPreference( PLAYER_MAP );
+            PlayerMapPreference playerPref = (PlayerMapPreference) findPreference( GamePrefs.PLAYER_MAP );
             playerPref.setMogaController( mMogaController );
         }
         
@@ -230,7 +221,7 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
     public void onSharedPreferenceChanged( SharedPreferences sharedPreferences, String key )
     {
         refreshViews();
-        if( key.equals( PLAY_SHOW_CHEATS ) )
+        if( key.equals( GamePrefs.PLAY_SHOW_CHEATS ) )
         {
             refreshCheatsCategory();
         }
@@ -284,11 +275,11 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
                 : R.string.screenCheats_summaryDisabled );
         
         // Enable/disable player map item as necessary
-        PrefUtil.enablePreference( this, PLAYER_MAP, mGamePrefs.playerMap.isEnabled() );
+        PrefUtil.enablePreference( this, GamePrefs.PLAYER_MAP, mGamePrefs.playerMap.isEnabled() );
         
         // Define which buttons to show in player map dialog
         @SuppressWarnings( "deprecation" )
-        PlayerMapPreference playerPref = (PlayerMapPreference) findPreference( PLAYER_MAP );
+        PlayerMapPreference playerPref = (PlayerMapPreference) findPreference( GamePrefs.PLAYER_MAP );
         if( playerPref != null )
         {
             // Check null in case preference has been removed

--- a/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
+++ b/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
@@ -93,9 +93,13 @@ public class ProfilePreference extends CompatibleListPreference
         //Find the default profile and add it
         Profile defaultProfile = null;
         if( configCustom.keySet().contains( defaultValue ) )
+        {
             defaultProfile =  new Profile( false, configCustom.get( defaultValue ) );
+        }
         else if( configBuiltin.keySet().contains( defaultValue ) )
+        {
             defaultProfile = new Profile( true, configBuiltin.get( defaultValue ) );
+        }
         
         //This is a fake profile that doesn't exist in any config file.
         //Selecting this profile will make us fall back to the current default profile
@@ -114,6 +118,13 @@ public class ProfilePreference extends CompatibleListPreference
             defaultProfile.setName(defaultProfileTitle.toString());
             
             //Add it at the beginning
+            profiles.add(0, defaultProfile);
+        }
+        else if (mAllowDisable)
+        {
+            defaultProfile = new Profile(true, defaultProfileTitle.toString(), getContext().getText(
+                R.string.listItem_disabled).toString());
+            // Add it at the beginning
             profiles.add(0, defaultProfile);
         }
         

--- a/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
+++ b/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
@@ -104,7 +104,6 @@ public class ProfilePreference extends CompatibleListPreference
         //This is a fake profile that doesn't exist in any config file.
         //Selecting this profile will make us fall back to the current default profile
         CharSequence defaultProfileTitle = getContext().getText( R.string.default_profile_title );
-        boolean noDefaultSelected = false;
         
         //Label it as default
         if(defaultProfile != null)
@@ -127,7 +126,6 @@ public class ProfilePreference extends CompatibleListPreference
                 R.string.listItem_disabled).toString());
             // Add it at the beginning
             profiles.add(0, defaultProfile);
-            noDefaultSelected = true;
         }
         
         int offset = mAllowDisable ? 1 : 0;
@@ -147,13 +145,6 @@ public class ProfilePreference extends CompatibleListPreference
                 entryHtml += "<br><small>" + profile.comment + "</small>";
             entries[i + offset] = Html.fromHtml( entryHtml );
             values[i + offset] = profile.name;
-        }
-        
-        //Make the value of the "Current Default" profile be an empty string
-        //if there is no default selected
-        if(noDefaultSelected)
-        {
-            values[1] = "";
         }
         
         // Set the list entries and values; select default if persisted selection no longer exists

--- a/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
+++ b/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
@@ -150,6 +150,7 @@ public class ProfilePreference extends CompatibleListPreference
         }
         
         //Make the value of the "Current Default" profile be an empty string
+        //if there is no default selected
         if(noDefaultSelected)
         {
             values[1] = "";
@@ -163,5 +164,10 @@ public class ProfilePreference extends CompatibleListPreference
             persistString( defaultProfileTitle.toString() );
         selectedValue = getPersistedString( null );
         setValue( selectedValue );
+    }
+    
+    public String getCurrentValue()
+    {
+        return getPersistedString( null );
     }
 }

--- a/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
+++ b/src/paulscode/android/mupen64plusae/preference/ProfilePreference.java
@@ -104,6 +104,7 @@ public class ProfilePreference extends CompatibleListPreference
         //This is a fake profile that doesn't exist in any config file.
         //Selecting this profile will make us fall back to the current default profile
         CharSequence defaultProfileTitle = getContext().getText( R.string.default_profile_title );
+        boolean noDefaultSelected = false;
         
         //Label it as default
         if(defaultProfile != null)
@@ -126,6 +127,7 @@ public class ProfilePreference extends CompatibleListPreference
                 R.string.listItem_disabled).toString());
             // Add it at the beginning
             profiles.add(0, defaultProfile);
+            noDefaultSelected = true;
         }
         
         int offset = mAllowDisable ? 1 : 0;
@@ -145,6 +147,12 @@ public class ProfilePreference extends CompatibleListPreference
                 entryHtml += "<br><small>" + profile.comment + "</small>";
             entries[i + offset] = Html.fromHtml( entryHtml );
             values[i + offset] = profile.name;
+        }
+        
+        //Make the value of the "Current Default" profile be an empty string
+        if(noDefaultSelected)
+        {
+            values[1] = "";
         }
         
         // Set the list entries and values; select default if persisted selection no longer exists

--- a/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
@@ -129,6 +129,12 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
     
     private final List<String> mProfileNames = new ArrayList<String>();
     
+    /** Profile list adapter */
+    private ProfileListAdapter mProfileListAdapter = null;
+    
+    /** Profile list **/
+    List<Profile> mProfileList = new ArrayList<Profile>();
+    
     @Override
     protected void onCreate( Bundle savedInstanceState )
     {
@@ -507,11 +513,19 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
     private void refreshList()
     {
         // Get the profiles to be shown to the user
-        List<Profile> profiles1 = Profile.getProfiles( mConfigCustom, false );
+        mProfileList.clear();
+        mProfileList.addAll( Profile.getProfiles( mConfigCustom, false ));
         if( getBuiltinVisibility() )
-            profiles1.addAll( Profile.getProfiles( mConfigBuiltin, true ) );
-        Collections.sort( profiles1 );
-        setListAdapter( new ProfileListAdapter( this, profiles1 ) );
+            mProfileList.addAll( Profile.getProfiles( mConfigBuiltin, true ) );
+        Collections.sort( mProfileList );
+        
+        if(mProfileListAdapter == null)
+        {
+            mProfileListAdapter = new ProfileListAdapter( this, mProfileList );
+            setListAdapter( mProfileListAdapter );
+        }
+
+        mProfileListAdapter.notifyDataSetChanged();
         
         // Get all profiles, for validating unique names
         List<Profile> profiles2 = Profile.getProfiles( mConfigCustom, false );

--- a/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
@@ -135,6 +135,10 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
     /** Profile list **/
     List<Profile> mProfileList = new ArrayList<Profile>();
     
+    /**Alert dialogs **/
+    AlertDialog mAlertDialogMenu = null;
+    AlertDialog mAlertDialogEditName = null;
+    
     @Override
     protected void onCreate( Bundle savedInstanceState )
     {
@@ -165,6 +169,24 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
         mConfigCustom.reload();
         refreshList();
     }
+    
+    @Override
+    protected void onPause()
+    {
+        super.onPause();
+        
+        if(mAlertDialogMenu != null)
+        {
+            mAlertDialogMenu.dismiss();
+        }
+        
+        if(mAlertDialogEditName != null)
+        {
+            mAlertDialogEditName.dismiss();
+        }
+    }
+    
+
     
     @Override
     public boolean onCreateOptionsMenu( Menu menu )
@@ -274,7 +296,8 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
                             }
                         }
                     } );
-            builder.create().show();
+            mAlertDialogMenu = builder.create();
+            mAlertDialogMenu.show();
         }
         super.onListItemClick( l, v, position, id );
     }
@@ -432,13 +455,14 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
         builder.setView( layout );
         builder.setPositiveButton( android.R.string.ok, clickListener );
         builder.setNegativeButton( android.R.string.cancel, clickListener );
-        final AlertDialog dialog = builder.create();
+        
+        mAlertDialogEditName = builder.create();
         
         // Show the dialog
-        dialog.show();
+        mAlertDialogEditName.show();
         
         // Dynamically disable the OK button if the name is not unique
-        final Button okButton = dialog.getButton( DialogInterface.BUTTON_POSITIVE );
+        final Button okButton = mAlertDialogEditName.getButton( DialogInterface.BUTTON_POSITIVE );
         String warning = isValidName( name, name, allowSameName );
         textWarning.setText( warning );
         okButton.setEnabled( TextUtils.isEmpty( warning ) );

--- a/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/ManageProfilesActivity.java
@@ -158,15 +158,7 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
         // Get the config files from the subclass-specified paths
         mConfigBuiltin = getConfigFile( true );
         mConfigCustom = getConfigFile( false );
-    }
-    
-    @Override
-    protected void onResume()
-    {
-        super.onResume();
         
-        // Reload in case we're returning from an editor
-        mConfigCustom.reload();
         refreshList();
     }
     
@@ -185,8 +177,6 @@ abstract public class ManageProfilesActivity extends AppCompatListActivity
             mAlertDialogEditName.dismiss();
         }
     }
-    
-
     
     @Override
     public boolean onCreateOptionsMenu( Menu menu )


### PR DESCRIPTION
* Did some refactoring so that some preference strings are no longer manually typed in more than one class.
* Now search for the default profile correctly if a controller profile is not found
* Renamed "Current Default" profile to "Global Default"
* Allow the "Global Default" profile to use the "Disabled" profile.
* The currently selected profile for a game can now be viewed without having to click on the option to set the profile.
* Several improvements to the ManageProfilesActivity