### PR TITLE
Mupen64plus core interaction enhancements and UI enhancements

### DIFF
--- a/res/menu/game_drawer.xml
+++ b/res/menu/game_drawer.xml
@@ -69,5 +69,8 @@
     <item
         android:id="@+id/menuItem_setIme"
         android:title="@string/menuItem_setIme"/>
+    <item
+        android:id="@+id/menuItem_reset"
+        android:title="@string/inputMapActivity_reset"/>
 
 </menu>

--- a/src/paulscode/android/mupen64plusae/game/GameActivity.java
+++ b/src/paulscode/android/mupen64plusae/game/GameActivity.java
@@ -87,11 +87,4 @@ public class GameActivity extends Activity
         super.onStop();
         mLifecycleHandler.onStop();
     }
-    
-    @Override
-    protected void onDestroy()
-    {        
-        super.onDestroy();
-        mLifecycleHandler.onDestroy();
-    }
 }

--- a/src/paulscode/android/mupen64plusae/game/GameActivityXperiaPlay.java
+++ b/src/paulscode/android/mupen64plusae/game/GameActivityXperiaPlay.java
@@ -95,11 +95,4 @@ public class GameActivityXperiaPlay extends NativeActivity
         super.onStop();
         mLifecycleHandler.onStop();
     }
-    
-    @Override
-    protected void onDestroy()
-    {        
-        super.onDestroy();
-        mLifecycleHandler.onDestroy();
-    }
 }

--- a/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
+++ b/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
@@ -51,6 +51,7 @@ import paulscode.android.mupen64plusae.jni.CoreInterface.OnPromptFinishedListene
 import paulscode.android.mupen64plusae.jni.CoreInterface.OnSaveLoadListener;
 import paulscode.android.mupen64plusae.jni.NativeConstants;
 import paulscode.android.mupen64plusae.jni.NativeExports;
+import paulscode.android.mupen64plusae.jni.NativeInput;
 import paulscode.android.mupen64plusae.jni.NativeXperiaTouchpad;
 import paulscode.android.mupen64plusae.persistent.AppData;
 import paulscode.android.mupen64plusae.persistent.GamePrefs;
@@ -564,6 +565,9 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
                         if( which == DialogInterface.BUTTON_POSITIVE )
                         {
                             mGlobalPrefs.putPakType(player, PakType.values()[value]);
+                            
+                            // Set the pak in the core
+                            NativeInput.setConfig( player - 1, true, PakType.values()[value].getNativeValue() );
                             
                             //Update the menu
                             playerMenuItem.setTitleCondensed(mActivity.getString(mGlobalPrefs.getPakType(player).getResourceString()));

--- a/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
+++ b/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
@@ -32,6 +32,7 @@ import paulscode.android.mupen64plusae.GameSidebar.GameSidebarActionHandler;
 import paulscode.android.mupen64plusae.dialog.Popups;
 import paulscode.android.mupen64plusae.dialog.Prompt;
 import paulscode.android.mupen64plusae.dialog.Prompt.PromptIntegerListener;
+import paulscode.android.mupen64plusae.game.GameSurface.GameSurfaceCreatedListener;
 import paulscode.android.mupen64plusae.hack.MogaHack;
 import paulscode.android.mupen64plusae.input.AbstractController;
 import paulscode.android.mupen64plusae.input.PeripheralController;
@@ -46,6 +47,7 @@ import paulscode.android.mupen64plusae.input.provider.KeyProvider.ImeFormula;
 import paulscode.android.mupen64plusae.input.provider.MogaProvider;
 import paulscode.android.mupen64plusae.jni.CoreInterface;
 import paulscode.android.mupen64plusae.jni.CoreInterface.OnPromptFinishedListener;
+import paulscode.android.mupen64plusae.jni.CoreInterface.OnSaveLoadListener;
 import paulscode.android.mupen64plusae.jni.NativeConstants;
 import paulscode.android.mupen64plusae.jni.NativeExports;
 import paulscode.android.mupen64plusae.jni.NativeXperiaTouchpad;
@@ -119,7 +121,7 @@ import com.bda.controller.Controller;
 */
 //@formatter:on
 
-public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebarActionHandler, OnPromptFinishedListener
+public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebarActionHandler, OnPromptFinishedListener, OnSaveLoadListener, GameSurfaceCreatedListener
 {
     // Activity and views
     private Activity mActivity;
@@ -149,7 +151,6 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     private final String mRomGoodName;
     
     // Lifecycle state tracking
-    private boolean mIsFocused = false;     // true if the window is focused
     private boolean mIsResumed = false;     // true if the activity is resumed
     private boolean mIsSurface = false;     // true if the surface is available
     
@@ -157,6 +158,8 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     private GlobalPrefs mGlobalPrefs;
     private GamePrefs mGamePrefs;
     private GameAutoSaveManager mAutoSaveManager;
+    private boolean mFirstStart;
+    private boolean mWaitingOnExitConfirmation = false;
     
     public GameLifecycleHandler( Activity activity )
     {
@@ -218,6 +221,8 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
         mGlobalPrefs = new GlobalPrefs( mActivity, appData );
         mGamePrefs = new GamePrefs( mActivity, mRomMd5, mRomCrc, mRomHeaderName,
                 RomHeader.countryCodeToSymbol(mRomCountryCode), appData, mGlobalPrefs );
+        
+        mFirstStart = true;
     }
     
     @TargetApi( 11 )
@@ -239,6 +244,7 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
 
         // Make the background solid black
         mSurface.getRootView().setBackgroundColor(0xFF000000);
+        mSurface.SetGameSurfaceCreatedListener(this);
 
         if (!TextUtils.isEmpty(mArtPath) && new File(mArtPath).exists())
             mGameSidebar.setImage(new BitmapDrawable(mActivity.getResources(), mArtPath));
@@ -308,25 +314,26 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
             @Override
             public void onDrawerClosed(View arg0)
             {
-                
+                NativeExports.emuResume();
             }
 
             @Override
             public void onDrawerOpened(View arg0)
             {
+                NativeExports.emuPause();
                 ReloadAllMenus();
             }
 
             @Override
             public void onDrawerSlide(View arg0, float arg1)
             {
-                
+
             }
 
             @Override
-            public void onDrawerStateChanged(int arg0)
+            public void onDrawerStateChanged(int newState)
             {
-                
+
             }
             
         });
@@ -397,12 +404,22 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     }
     
     @Override
+    public void onSaveLoad()
+    {
+        if( mDrawerLayout.isDrawerOpen( GravityCompat.START ) )
+        {
+            mDrawerLayout.closeDrawer( GravityCompat.START );
+        }
+    }
+    
+    @Override
     public void onGameSidebarAction(MenuItem menuItem)
     {
         switch (menuItem.getItemId())
         {
         case R.id.menuItem_exit:
-            CoreInterface.exit();
+            mWaitingOnExitConfirmation = true;
+            CoreInterface.exit(!mDrawerLayout.isDrawerOpen( GravityCompat.START ));
             break;
         case R.id.menuItem_toggle_speed:
             CoreInterface.toggleSpeed();
@@ -423,19 +440,23 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
             CoreInterface.setSlotFromPrompt(this);
             break;
         case R.id.menuItem_slot_load:
-            CoreInterface.loadSlot();
+            CoreInterface.loadSlot(this);
             break;
         case R.id.menuItem_slot_save:
-            CoreInterface.saveSlot();
+            CoreInterface.saveSlot(this);
+            if( mDrawerLayout.isDrawerOpen( GravityCompat.START ) )
+            {
+                mDrawerLayout.closeDrawer( GravityCompat.START );
+            }
             break;
         case R.id.menuItem_file_load:
-            CoreInterface.loadFileFromPrompt();
+            CoreInterface.loadFileFromPrompt(this);
             break;
         case R.id.menuItem_file_save:
-            CoreInterface.saveFileFromPrompt();
+            CoreInterface.saveFileFromPrompt(this);
             break;
         case R.id.menuItem_file_load_auto_save:
-            CoreInterface.loadAutoSaveFromPrompt();
+            CoreInterface.loadAutoSaveFromPrompt(this);
             break;
         case R.id.menuItem_disable_frame_limiter:
             CoreInterface.toggleFramelimiter();
@@ -451,25 +472,17 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
             mGameSidebar.reload();
             break;
         case R.id.menuItem_player_one:
-        {
             setPakTypeFromPrompt(1, mGlobalPrefs.getPakType(1).ordinal(), this);
             break;
-        }
         case R.id.menuItem_player_two:
-        {
             setPakTypeFromPrompt(2, mGlobalPrefs.getPakType(2).ordinal(), this);
             break;
-        }
         case R.id.menuItem_player_three:
-        {
             setPakTypeFromPrompt(3, mGlobalPrefs.getPakType(3).ordinal(), this);
             break;
-        }
         case R.id.menuItem_player_four:
-        {
             setPakTypeFromPrompt(4, mGlobalPrefs.getPakType(4).ordinal(), this);
             break;
-        }
         case R.id.menuItem_setIme:
             InputMethodManager imeManager = (InputMethodManager) mActivity
                 .getSystemService(Context.INPUT_METHOD_SERVICE);
@@ -529,8 +542,6 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     public void setPakTypeFromPrompt(final int player, final int selectedPakType,
         final OnPromptFinishedListener promptFinishedListener)
     {
-        NativeExports.emuPause();
-
         //First get the prompt title
         CharSequence title = GetPlayerTextFromId(player);
         final MenuItem playerMenuItem = GetPlayerMenuItemFromId(player);
@@ -556,7 +567,6 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
                             playerMenuItem.setTitleCondensed(mActivity.getString(mGlobalPrefs.getPakType(player).getResourceString()));
                             mGameSidebar.reload();
                         }
-                        NativeExports.emuResume();
                     }
                 } );
     }
@@ -571,7 +581,12 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     {
         Log.i("GameLifecycleHandler", "onResume");
         mIsResumed = true;
-        tryRunning();
+        
+        if(mFirstStart)
+        {
+            tryRunning();
+            mFirstStart = false;
+        }
 
         // Set the sidebar opacity
         mGameSidebar.setBackgroundDrawable(new DrawerDrawable(
@@ -599,10 +614,17 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     {
         // Only try to run; don't try to pause. User may just be touching the in-game menu.
         Log.i( "GameLifecycleHandler", "onWindowFocusChanged: " + hasFocus );
-        mIsFocused = hasFocus;
         if( hasFocus )
             hideSystemBars();
-        tryRunning();
+        
+        //We don't want to do this every time the user uses a dialog,
+        //only do it when the activity is first created.
+        if(mFirstStart)
+        {
+            tryRunning();
+            mFirstStart = false;
+        }
+        
     }
     
     public void onPause()
@@ -658,9 +680,14 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
         else if( keyDown && keyCode == KeyEvent.KEYCODE_BACK )
         {
             if( mDrawerLayout.isDrawerOpen( GravityCompat.START ) )
+            {
                 mDrawerLayout.closeDrawer( GravityCompat.START );
+            }
             else
-                CoreInterface.exit();
+            {
+                mWaitingOnExitConfirmation = true;
+                CoreInterface.exit(true);
+            }
             return true;
         }
         
@@ -828,7 +855,7 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     
     private boolean isSafeToRender()
     {
-        return mIsFocused && mIsResumed && mIsSurface;
+        return mIsResumed && mIsSurface;
     }
     
     private void tryRunning()
@@ -843,7 +870,8 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
                     CoreInterface.startupEmulator(latestSave);
                     break;
                 case NativeConstants.EMULATOR_STATE_PAUSED:
-                    if( mSurface.isEGLContextReady() )
+                    if( mSurface.isEGLContextReady() && !mDrawerLayout.isDrawerOpen( GravityCompat.START )
+                        && !mWaitingOnExitConfirmation)
                         CoreInterface.resumeEmulator();
                     break;
                 default:
@@ -856,5 +884,19 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     {
         if( NativeExports.emuGetState() != NativeConstants.EMULATOR_STATE_PAUSED )
             CoreInterface.pauseEmulator( false, null );
+    }
+
+    @Override
+    public void onGameSurfaceCreated()
+    {
+        if( !mDrawerLayout.isDrawerOpen( GravityCompat.START ) )
+        {
+            NativeExports.emuResume();
+        }
+        else
+        {
+            //Advance 1 frame so that something is shown instead of a black screen
+            CoreInterface.advanceFrame();
+        }
     }
 }

--- a/src/paulscode/android/mupen64plusae/game/GameSurface.java
+++ b/src/paulscode/android/mupen64plusae/game/GameSurface.java
@@ -29,8 +29,6 @@ import javax.microedition.khronos.egl.EGLContext;
 import javax.microedition.khronos.egl.EGLDisplay;
 import javax.microedition.khronos.egl.EGLSurface;
 
-import paulscode.android.mupen64plusae.jni.NativeConstants;
-import paulscode.android.mupen64plusae.jni.NativeExports;
 import android.content.Context;
 import android.opengl.GLES10;
 import android.util.AttributeSet;
@@ -42,6 +40,13 @@ import android.view.SurfaceView;
  */
 public class GameSurface extends SurfaceView
 {
+    //Listener for a game surface created event
+    public interface GameSurfaceCreatedListener
+    {
+        //This is called every time the game surface is created
+        public void onGameSurfaceCreated();
+    }
+    
     // LogCat strings for debugging, defined here to simplify maintenance/lookup
     private static final String TAG = "GameSurface";
     
@@ -96,6 +101,9 @@ public class GameSurface extends SurfaceView
     
     private boolean mIsEGLContextReady = false;     // true if the context is ready
     
+    //Game surface created listener
+    GameSurfaceCreatedListener mGameSurfaceCreatedListener = null;
+    
     /**
      * Constructor that is called when inflating a view from XML. This is called when a view is
      * being constructed from an XML file, supplying attributes that were specified in the XML file.
@@ -110,6 +118,15 @@ public class GameSurface extends SurfaceView
     public GameSurface( Context context, AttributeSet attribs )
     {
         super( context, attribs );
+    }
+    
+    /**
+     * Set the game surface created listener
+     * @param gameSurfaceCreatedListener Game surface created listener
+     */
+    public void SetGameSurfaceCreatedListener(GameSurfaceCreatedListener gameSurfaceCreatedListener)
+    {
+        mGameSurfaceCreatedListener = gameSurfaceCreatedListener;
     }
     
     /**
@@ -145,8 +162,10 @@ public class GameSurface extends SurfaceView
                         String version = GLES10.glGetString( GLES10.GL_VERSION );
                         Log.i( TAG, "Created GL context " + version );
                         
-                        if( NativeExports.emuGetState() != NativeConstants.EMULATOR_STATE_RUNNING )
-                            NativeExports.emuResume();
+                        if(mGameSurfaceCreatedListener != null)
+                        {
+                            mGameSurfaceCreatedListener.onGameSurfaceCreated();
+                        }
                         
                         mIsEGLContextReady = true;
                         return true;

--- a/src/paulscode/android/mupen64plusae/input/PeripheralController.java
+++ b/src/paulscode/android/mupen64plusae/input/PeripheralController.java
@@ -226,11 +226,11 @@ public class PeripheralController extends AbstractController implements
                     break;
                 case InputMap.FUNC_SAVE_SLOT:
                     Log.v( "PeripheralController", "FUNC_SAVE_SLOT" );
-                    CoreInterface.saveSlot();
+                    CoreInterface.saveSlot(null);
                     break;
                 case InputMap.FUNC_LOAD_SLOT:
                     Log.v( "PeripheralController", "FUNC_LOAD_SLOT" );
-                    CoreInterface.loadSlot();
+                    CoreInterface.loadSlot(null);
                     break;
                 case InputMap.FUNC_RESET:
                     Log.v( "PeripheralController", "FUNC_RESET" );

--- a/src/paulscode/android/mupen64plusae/input/PeripheralController.java
+++ b/src/paulscode/android/mupen64plusae/input/PeripheralController.java
@@ -234,7 +234,7 @@ public class PeripheralController extends AbstractController implements
                     break;
                 case InputMap.FUNC_RESET:
                     Log.v( "PeripheralController", "FUNC_RESET" );
-                    CoreInterface.restartEmulator();
+                    CoreInterface.restart();
                     break;
                 case InputMap.FUNC_STOP:
                     Log.v( "PeripheralController", "FUNC_STOP" );

--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -304,7 +304,6 @@ public class CoreInterface
             // Auto-load state if desired
             if( !sIsRestarting)
             {
-                Notifier.showToast( sActivity, R.string.toast_loadingSession );
                 addOnStateCallbackListener( new OnStateCallbackListener()
                 {
                     @Override
@@ -316,6 +315,16 @@ public class CoreInterface
                         {
                             removeOnStateCallbackListener( this );
                             NativeExports.emuLoadFile( saveToLoad );
+
+                            sActivity.runOnUiThread(new Runnable()
+                            {
+                                @Override
+                                public void run()
+                                {
+                                    Notifier.showToast(sActivity, R.string.toast_loadingSession);
+
+                                }
+                            });
                         }
                     }
                 } );

--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -84,8 +84,6 @@ public class CoreInterface
     {
         /**
          * Called when a prompt is complete
-         * 
-         * @param newValue The new FPS value.
          */
         public void onPromptFinished();
     }
@@ -93,9 +91,18 @@ public class CoreInterface
     public interface OnSaveLoadListener
     {
         /**
-         * Called when a save is loaded
+         * Called when a game is saved or a save is loaded
          */
         public void onSaveLoad();
+    }
+    
+    public interface OnExitListener
+    {
+        /**
+         * Called when a game is exited
+         * @param True if we want to exit
+         */
+        public void onExit(boolean shouldExit);
     }
     
     // Haptic objects - used by NativeInput
@@ -638,7 +645,7 @@ public class CoreInterface
         NativeExports.emuAdvanceFrame();
     }
     
-    public static void exit(final boolean mResumeOnCancel)
+    public static void exit(final OnExitListener onExitListener)
     {
         NativeExports.emuPause();
         String title = sActivity.getString( R.string.confirm_title );
@@ -648,14 +655,7 @@ public class CoreInterface
             @Override
             public void onDialogClosed( int which )
             {
-                if( which == DialogInterface.BUTTON_POSITIVE )
-                {
-                    sActivity.finish();
-                }
-                else if (mResumeOnCancel)
-                {
-                    NativeExports.emuResume();
-                }
+                onExitListener.onExit( which == DialogInterface.BUTTON_POSITIVE );
             }
         } );
     }

--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -105,6 +105,15 @@ public class CoreInterface
         public void onExit(boolean shouldExit);
     }
     
+    public interface OnRestartListener
+    {
+        /**
+         * Called when a game is restarted
+         * @param True if we want to restart
+         */
+        public void onRestart(boolean shouldRestart);
+    }
+    
     // Haptic objects - used by NativeInput
     protected static final Vibrator[] sVibrators = new Vibrator[4];
     
@@ -366,12 +375,6 @@ public class CoreInterface
             // Unload the native libraries
             NativeExports.unloadLibraries();
         }
-    }
-    
-    public static synchronized void restartEmulator()
-    {
-        shutdownEmulator();
-        startupEmulator(null);
     }
     
     public static synchronized void resumeEmulator()
@@ -643,6 +646,30 @@ public class CoreInterface
     {
         NativeExports.emuPause();
         NativeExports.emuAdvanceFrame();
+    }
+    
+    public static synchronized void restart()
+    {
+        CoreInterface.shutdownEmulator();
+        CoreInterface.startupEmulator(null);
+    }
+    
+    public static synchronized void restart(final OnRestartListener onRestartListener)
+    {        
+        NativeExports.emuPause();
+        String title = sActivity.getString( R.string.confirm_title );
+        String message = sActivity.getString( R.string.confirmResetGame_message );
+        Prompt.promptConfirm( sActivity, title, message, new PromptConfirmListener()
+        {
+            @Override
+            public void onDialogClosed( int which )
+            {
+                if(onRestartListener != null)
+                {
+                    onRestartListener.onRestart( which == DialogInterface.BUTTON_POSITIVE );
+                }
+            }
+        } );
     }
     
     public static void exit(final OnExitListener onExitListener)


### PR DESCRIPTION
* Gameplay will be restored automatically and the sidebar closed if a slot or file is loaded or saved. This involved fixing a lot of corner cases.

* The gallery game side bar is now closed automatically when launching a game. This forces a refresh of the gallery sidebar so the the resume button shows up when a game is opened for the first time.

* Now no longer showing the toast staying that a game is being resumed when a game is being restarted. This is done correctly this time.

* We will now no longer exit the GameActivity immediately after a user chooses to exit. We will now wait until the core is done fully shutting down.

* Added a reset option to the in-game sidebar.