### PR TITLE
Now saving game state when the home button is hit.

### DIFF
--- a/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
+++ b/src/paulscode/android/mupen64plusae/game/GameLifecycleHandler.java
@@ -656,6 +656,10 @@ public class GameLifecycleHandler implements SurfaceHolder.Callback, GameSidebar
     public void onStop()
     {
         Log.i( "GameLifecycleHandler", "onStop" );
+        
+        String saveFileName = mAutoSaveManager.getAutoSaveFileName();
+        CoreInterface.pauseEmulator( true, saveFileName );
+        mAutoSaveManager.clearOldest();
     }
     
     @Override

--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -385,24 +385,37 @@ public class CoreInterface
         }
     }
     
-    public static synchronized void pauseEmulator( boolean autoSave, String latestSave )
+    public static synchronized void pauseEmulator(boolean autoSave, String latestSave)
     {
-        if( sCoreThread != null )
+        if (sCoreThread != null)
         {
-            NativeExports.emuPause();
-            
-            // Auto-save in case device doesn't resume properly (e.g. OS kills process, battery dies, etc.)
-            if( autoSave && latestSave != null)
-            {                
+
+            // Auto-save in case device doesn't resume properly (e.g. OS kills
+            // process, battery dies, etc.)
+            if (autoSave && latestSave != null)
+            {
+                NativeExports.emuSaveFile(latestSave);
                 
-                Notifier.showToast( sActivity, R.string.toast_savingSession );
-                
+                //For some reason, the core refuses to save unless
+                //it's running for at least a small amount of time
+                NativeExports.emuResume();
+                try
+                {
+                    Thread.sleep(100);
+                }
+                catch (InterruptedException e)
+                {
+                    e.printStackTrace();
+                }
+                Notifier.showToast(sActivity, R.string.toast_savingSession);
+
                 Log.i("CoreInterface", "Saving file: " + latestSave);
-                NativeExports.emuSaveFile( latestSave );
             }
+
+            NativeExports.emuPause();
         }
     }
-    
+
     public static void togglePause()
     {
         int state = NativeExports.emuGetState();


### PR DESCRIPTION
Currently, if a user goes home and then kills the app or the OS kills the app, the game state will not be saved.

This fixes that issue. Also, one oddity, for some reason the Core refuses to save the game unless it's resumed for at least 100ms.