### PR TITLE
Allow mapped controllers to automatically reconnect.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -502,6 +502,7 @@
     <!-- Player Mapping -->
     <string name="playerMap_deviceWithName">Device %1$d (%2$s)</string>
     <string name="playerMap_deviceWithoutName">Device %1$d</string>
+    <string name="playerMap_deviceNotConnected">Not Connected</string>
     <string name="playerMapPreference_popupTitle">Player %1$d</string>
     <string name="playerMapPreference_popupMessage">Player %1$d, press a button or stick on your controller…\n\nCurrent devices:\n%2$s</string>
     <string name="playerMapPreference_popupUnmap">Unmap</string>

--- a/src/paulscode/android/mupen64plusae/game/GameActivity.java
+++ b/src/paulscode/android/mupen64plusae/game/GameActivity.java
@@ -706,7 +706,6 @@ OnPromptFinishedListener, OnSaveLoadListener, GameSurfaceCreatedListener, OnExit
         boolean keyDown = event.getAction() == KeyEvent.ACTION_DOWN;
         
         // Attempt to reconnect any disconnected devices
-        // TODO: Show message on screen when reconnection was successful?
         mGamePrefs.playerMap.reconnectDevice( AbstractProvider.getHardwareId( event ) );
         
         if( keyDown && keyCode == KeyEvent.KEYCODE_MENU )

--- a/src/paulscode/android/mupen64plusae/game/GameActivity.java
+++ b/src/paulscode/android/mupen64plusae/game/GameActivity.java
@@ -705,6 +705,10 @@ OnPromptFinishedListener, OnSaveLoadListener, GameSurfaceCreatedListener, OnExit
     {
         boolean keyDown = event.getAction() == KeyEvent.ACTION_DOWN;
         
+        // Attempt to reconnect any disconnected devices
+        // TODO: Show message on screen when reconnection was successful?
+        mGamePrefs.playerMap.reconnectDevice( AbstractProvider.getHardwareId( event ) );
+        
         if( keyDown && keyCode == KeyEvent.KEYCODE_MENU )
         {
             if( mDrawerLayout.isDrawerOpen( GravityCompat.START ) )

--- a/src/paulscode/android/mupen64plusae/input/map/PlayerMap.java
+++ b/src/paulscode/android/mupen64plusae/input/map/PlayerMap.java
@@ -104,7 +104,7 @@ public class PlayerMap extends SerializableMap
                 int deviceId = mMap.keyAt( i );
                 String name = AbstractProvider.isHardwareAvailable( deviceId ) ?
                         AbstractProvider.getHardwareName( deviceId ) :
-                        "Not Connected";
+                        context.getString( R.string.playerMap_deviceNotConnected );
                 if( name == null )
                     result += context.getString( R.string.playerMap_deviceWithoutName, deviceId );
                 else

--- a/src/paulscode/android/mupen64plusae/input/map/PlayerMap.java
+++ b/src/paulscode/android/mupen64plusae/input/map/PlayerMap.java
@@ -20,6 +20,9 @@
  */
 package paulscode.android.mupen64plusae.input.map;
 
+import java.util.HashMap;
+import java.util.Map.Entry;
+
 import org.mupen64plusae.v3.alpha.R;
 
 import paulscode.android.mupen64plusae.input.provider.AbstractProvider;
@@ -30,6 +33,11 @@ public class PlayerMap extends SerializableMap
 {
     /** Flag indicating whether hardware filtering is enabled. */
     boolean mDisabled = true;
+    
+    /** A map where the device unique name maps to an id.
+     *  When the device reconnects and it is given a new id,
+     *  this map allows the old id to be looked up so it can be replaced with the new id. */
+    private HashMap<String, Integer> deviceNameToId = new HashMap<String, Integer>();
     
     /**
      * Instantiates a new player map.
@@ -45,7 +53,8 @@ public class PlayerMap extends SerializableMap
      */
     public PlayerMap( String serializedMap )
     {
-        super( serializedMap );
+        super();
+        deserialize( serializedMap );
     }
     
     public boolean testHardware( int hardwareId, int player )
@@ -79,7 +88,9 @@ public class PlayerMap extends SerializableMap
             if( mMap.valueAt( i ) == player )
             {
                 int deviceId = mMap.keyAt( i );
-                String name = AbstractProvider.getHardwareName( deviceId );
+                String name = AbstractProvider.isHardwareAvailable( deviceId ) ?
+                        AbstractProvider.getHardwareName( deviceId ) :
+                        "Not Connected";
                 if( name == null )
                     result += context.getString( R.string.playerMap_deviceWithoutName, deviceId );
                 else
@@ -90,6 +101,37 @@ public class PlayerMap extends SerializableMap
         return result.trim();
     }
     
+    /**
+     * Attempts to reconnect the specified device.
+     */
+    public boolean reconnectDevice( int hardwareId )
+    {
+        // If the device is not mapped to any player...
+        if( mMap.get( hardwareId ) == 0 && AbstractProvider.isHardwareAvailable( hardwareId ) )
+        {
+            // ...and if the device was previously mapped to a player...
+            String uniqueName = AbstractProvider.getUniqueName( hardwareId );
+            Integer oldId = deviceNameToId.get( uniqueName );
+            
+            if( oldId != null && !AbstractProvider.isHardwareAvailable( oldId ) )
+            {
+                int player = mMap.get( oldId );
+                
+                if( player > 0 )
+                {
+                    // ...then replace the old id with the new one.
+                    Log.v( "PlayerMap", "Reconnecting device " + oldId + " as " + hardwareId + " for player " + player );
+                    mMap.delete( oldId );
+                    mMap.append( hardwareId, player );
+                    deviceNameToId.put( uniqueName, hardwareId );
+                    return true;
+                }
+            }
+        }
+        
+        return false;
+    }
+    
     public boolean isMapped( int player )
     {
         return mMap.indexOfValue( player ) >= 0;
@@ -98,7 +140,11 @@ public class PlayerMap extends SerializableMap
     public void map( int hardwareId, int player )
     {
         if( player > 0 && player < 5 )
+        {
+            unmap( hardwareId );
             mMap.put( hardwareId, player );
+            deviceNameToId.put( AbstractProvider.getUniqueName( hardwareId ), hardwareId );
+        }
         else
             Log.w( "InputMap", "Invalid player specified in map(.,.): " + player );
     }
@@ -106,6 +152,15 @@ public class PlayerMap extends SerializableMap
     public void unmap( int hardwareId )
     {
         mMap.delete( hardwareId );
+        
+        for( Entry<String, Integer> entry : deviceNameToId.entrySet() )
+        {
+            if( entry.getValue() == hardwareId )
+            {
+                deviceNameToId.remove( entry.getKey() );
+                break;
+            }
+        }
     }
     
     public void unmapPlayer( int player )
@@ -113,8 +168,15 @@ public class PlayerMap extends SerializableMap
         for( int index = mMap.size() - 1; index >= 0; index-- )
         {
             if( mMap.valueAt( index ) == player )
-                mMap.removeAt( index );
+                unmap( mMap.keyAt( index ) );
         }
+    }
+    
+    @Override
+    public void unmapAll()
+    {
+        deviceNameToId.clear();
+        super.unmapAll();
     }
     
     public void removeUnavailableMappings()
@@ -125,15 +187,89 @@ public class PlayerMap extends SerializableMap
             if( !AbstractProvider.isHardwareAvailable( id ) )
             {
                 Log.v( "PlayerMap", "Removing device " + id + " from map" );
-                mMap.removeAt( i );
+                unmap( id );
             }
         }
     }
     
+    /**
+     * Serializes the map data to a string.
+     * 
+     * @return The string representation of the map data.
+     */
+    @Override
+    public String serialize()
+    {
+        // Serialize the map data to a multi-delimited string
+        String result = "";
+        
+        for( Entry<String, Integer> entry : deviceNameToId.entrySet() )
+        {
+            // If the device name is the id, then store the latest id, otherwise the device's unique name
+            String device = ( Integer.getInteger( entry.getKey(), 0 ) != 0 ) ?
+                    entry.getValue().toString() :
+                    entry.getKey();
+            int player = mMap.get( entry.getValue() );
+            
+            // Putting the value first makes the string a bit more human readable IMO
+            if( player > 0 && device != null )
+                result += player + ":" + device + ",";
+        }
+        
+        return result;
+    }
+    
+    /**
+     * Deserializes the map data from a string.
+     * 
+     * @param s The string representation of the map data.
+     */
     @Override
     public void deserialize( String s )
     {
-        super.deserialize( s );
-        removeUnavailableMappings();
+        // Reset the map
+        unmapAll();
+        
+        // Parse the new map data from the multi-delimited string
+        if( s != null )
+        {
+            int psuedoId = -100;
+            
+            // Read the input mappings
+            String[] pairs = s.split( "," );
+            for( String pair : pairs )
+            {
+                String[] elements = pair.split( ":" );
+                if( elements.length == 2 )
+                {
+                    try
+                    {
+                        int player = Integer.parseInt( elements[0] );
+                        int id = AbstractProvider.getHardwareId( elements[1] );
+                        
+                        // If the specified device is not currently connected.
+                        if( id == 0 )
+                        {
+                            // Do not add disconnected devices if the key specified is a device id.
+                            if( Integer.getInteger( elements[1], 0 ) != 0 )
+                                continue;
+                            
+                            id = psuedoId;
+                            psuedoId--;
+                        }
+                        
+                        // This will update the device name when transitioning from device ids and add it to the map.
+                        String deviceName = id > 0 ?
+                                AbstractProvider.getUniqueName( id ) :
+                                elements[1];
+                        deviceNameToId.put( deviceName , id );
+                        mMap.put( id, player );
+                    }
+                    catch( NumberFormatException ignored )
+                    {
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/paulscode/android/mupen64plusae/input/provider/AbstractProvider.java
+++ b/src/paulscode/android/mupen64plusae/input/provider/AbstractProvider.java
@@ -187,11 +187,13 @@ public abstract class AbstractProvider
             }
         }
         
+        // Check all the connected devices
         int[] deviceIds = InputDevice.getDeviceIds();
         
         for( int i = 0; i < deviceIds.length; i++ )
         {
-            if( uniqueName.equals( getUniqueName( deviceIds[i] ) ) )
+            if( uniqueName.equals( getUniqueName( deviceIds[i] ) ) ||
+                    uniqueName.equals( Integer.toString( deviceIds[i] ) ) )
             {
                 return deviceIds[i];
             }

--- a/src/paulscode/android/mupen64plusae/input/provider/AbstractProvider.java
+++ b/src/paulscode/android/mupen64plusae/input/provider/AbstractProvider.java
@@ -24,6 +24,7 @@ import paulscode.android.mupen64plusae.input.map.InputMap;
 import paulscode.android.mupen64plusae.persistent.AppData;
 import paulscode.android.mupen64plusae.util.SubscriptionManager;
 import tv.ouya.console.api.OuyaController;
+import android.annotation.SuppressLint;
 import android.view.InputDevice;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -70,6 +71,9 @@ public abstract class AbstractProvider
     
     /** The strength threshold above which an input is said to be "on". */
     public static final float STRENGTH_THRESHOLD = 0.5f;
+    
+    /** The prefix used for Moga devices. */
+    private static final String mogaPrefix = "moga-";
     
     /** Listener management. */
     private final SubscriptionManager<AbstractProvider.OnInputListener> mPublisher;
@@ -163,6 +167,40 @@ public abstract class AbstractProvider
     }
     
     /**
+     * Obtains unique hardware id from a unique device name.
+     * 
+     * @param uniqueName The unique name of the device.
+     * 
+     * @return The unique identifier of the hardware.
+     */
+    public static int getHardwareId( String uniqueName )
+    {
+        if( uniqueName.startsWith( mogaPrefix ) )
+        {
+            try
+            {
+                return Integer.parseInt( uniqueName.substring( mogaPrefix.length() ) ) +
+                        HARDWARE_ID_MOGA_OFFSET;
+            }
+            catch( NumberFormatException ignored )
+            {
+            }
+        }
+        
+        int[] deviceIds = InputDevice.getDeviceIds();
+        
+        for( int i = 0; i < deviceIds.length; i++ )
+        {
+            if( uniqueName.equals( getUniqueName( deviceIds[i] ) ) )
+            {
+                return deviceIds[i];
+            }
+        }
+        
+        return 0;
+    }
+    
+    /**
      * Determines whether the hardware is available. This is a conservative test in that it will
      * return true if the availability cannot be conclusively determined.
      * 
@@ -196,13 +234,41 @@ public abstract class AbstractProvider
     {
         if( id > HARDWARE_ID_MOGA_OFFSET && id <= HARDWARE_ID_MOGA_MAX )
         {
-            return "moga-" + ( id - HARDWARE_ID_MOGA_OFFSET );
+            return mogaPrefix + ( id - HARDWARE_ID_MOGA_OFFSET );
         }
         else
         {
             InputDevice device = InputDevice.getDevice( id );
             return device == null ? null : device.getName();
         }
+    }
+    
+    /**
+     * Gets the unique name of the device.
+     * 
+     * @param id The unique hardware identifier.
+     * 
+     * @return The unique name of the device, or null if hardware not found.
+     */
+
+    @SuppressLint("NewApi")
+	public static String getUniqueName( int id )
+    {
+        if( id > HARDWARE_ID_MOGA_OFFSET && id <= HARDWARE_ID_MOGA_MAX )
+        {
+            return mogaPrefix + ( id - HARDWARE_ID_MOGA_OFFSET );
+        }
+        else if( AppData.IS_JELLY_BEAN )
+        {
+            InputDevice device = InputDevice.getDevice( id );
+            
+            if( device != null )
+            {
+                return device.getDescriptor();
+            }
+        }
+        
+        return String.valueOf( id );
     }
     
     /**


### PR DESCRIPTION
This commit will allow mapped controllers to be remembered by their device "descriptor" rather than the device id. This will allow controllers that have been disconnected and reconnected to be automatically remapped when one of the buttons is pressed. Also, deserialization should be compatible with current saved controller settings.

Note that in-game controller processing still uses the device ids for performance reasons. Also note that pre-Jelly Bean devices must still use device ids, and I was unable to test this with my setup.