### PR TITLE
Added global settings for controller profile and player map.

### DIFF
--- a/res/xml/preferences_global.xml
+++ b/res/xml/preferences_global.xml
@@ -212,6 +212,41 @@
             android:key="inputShareController"
             android:summary="@string/inputShareController_summary"
             android:title="@string/inputShareController_title" />
+
+        <paulscode.android.mupen64plusae.preference.ProfilePreference
+            android:icon="@drawable/ic_gamepad"
+            android:key="controllerProfile1"
+            android:summary="@string/selectedValue"
+            android:title="@string/controllerProfile1_title"
+            mupen64:allowDisable="true"
+            mupen64:managerAction=".profile.ManageControllerProfilesActivity" />
+        <paulscode.android.mupen64plusae.preference.ProfilePreference
+            android:icon="@drawable/ic_gamepad"
+            android:key="controllerProfile2"
+            android:summary="@string/selectedValue"
+            android:title="@string/controllerProfile2_title"
+            mupen64:allowDisable="true"
+            mupen64:managerAction=".profile.ManageControllerProfilesActivity" />
+        <paulscode.android.mupen64plusae.preference.ProfilePreference
+            android:icon="@drawable/ic_gamepad"
+            android:key="controllerProfile3"
+            android:summary="@string/selectedValue"
+            android:title="@string/controllerProfile3_title"
+            mupen64:allowDisable="true"
+            mupen64:managerAction=".profile.ManageControllerProfilesActivity" />
+        <paulscode.android.mupen64plusae.preference.ProfilePreference
+            android:icon="@drawable/ic_gamepad"
+            android:key="controllerProfile4"
+            android:summary="@string/selectedValue"
+            android:title="@string/controllerProfile4_title"
+            mupen64:allowDisable="true"
+            mupen64:managerAction=".profile.ManageControllerProfilesActivity" />
+
+        <paulscode.android.mupen64plusae.preference.PlayerMapPreference
+            android:icon="@drawable/ic_users"
+            android:key="playerMap"
+            android:summary="@string/playerMap_summary"
+            android:title="@string/playerMap_title" />
     </android.support.v7.preference.PreferenceCategory>
     <android.support.v7.preference.PreferenceCategory
         android:key="categoryData"

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefs.java
@@ -292,21 +292,26 @@ public class GamePrefs
         }
         
         // Controller profiles
-        controllerProfile1 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE1,
-                globalPrefs.getControllerProfileDefault(),
+        controllerProfile1 = loadControllerProfile( mPreferences, globalPrefs, CONTROLLER_PROFILE1,
+                globalPrefs.getControllerProfileDefault(1),
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile2 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE2,
-                "",
+        controllerProfile2 = loadControllerProfile( mPreferences, globalPrefs, CONTROLLER_PROFILE2,
+                globalPrefs.getControllerProfileDefault(2),
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile3 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE3,
-                "",
+        controllerProfile3 = loadControllerProfile( mPreferences, globalPrefs, CONTROLLER_PROFILE3,
+                globalPrefs.getControllerProfileDefault(3),
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
-        controllerProfile4 = loadControllerProfile( mPreferences, CONTROLLER_PROFILE4,
-                "",
+        controllerProfile4 = loadControllerProfile( mPreferences, globalPrefs, CONTROLLER_PROFILE4,
+                globalPrefs.getControllerProfileDefault(4),
                 globalPrefs.GetControllerProfilesConfig(), appData.GetControllerProfilesConfig() );
         
         // Player map
-        playerMap = new PlayerMap( mPreferences.getString( PLAYER_MAP, "" ) );
+        String playerMapString = mPreferences.getString( PLAYER_MAP, "" );
+        
+        if( playerMapString.isEmpty() )
+            playerMapString = globalPrefs.getString( PLAYER_MAP, "" );
+        
+        playerMap = new PlayerMap( playerMapString );
         
         // Cheats menu
         isCheatOptionsShown = mPreferences.getBoolean( PLAY_SHOW_CHEATS, false );
@@ -601,10 +606,11 @@ public class GamePrefs
             return null;
     }
     
-    private static ControllerProfile loadControllerProfile( SharedPreferences prefs, String key,
-            String defaultName, ConfigFile custom, ConfigFile builtin )
+    private static ControllerProfile loadControllerProfile( SharedPreferences prefs, GlobalPrefs globalPrefs,
+            String key, String defaultName, ConfigFile custom, ConfigFile builtin )
     {
-        final String name = prefs.getString( key, defaultName );
+        String globalName = globalPrefs.getString( key, defaultName );
+        final String name = prefs.getString( key, globalName );
         
         if( custom.keySet().contains( name ) )
             return new ControllerProfile( false, custom.get( name ) );

--- a/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
+++ b/src/paulscode/android/mupen64plusae/persistent/GamePrefsActivity.java
@@ -283,28 +283,28 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
         if(mControllerProfile1 != null)
         {
             mControllerProfile1.populateProfiles( mAppData.GetControllerProfilesConfig(),
-                mGlobalPrefs.GetControllerProfilesConfig(), mGlobalPrefs.getControllerProfileDefault() );
+                mGlobalPrefs.GetControllerProfilesConfig(), mGlobalPrefs.getControllerProfileDefault(1) );
             mControllerProfile1.setSummary(mControllerProfile1.getCurrentValue());
         }
         
         if(mControllerProfile2 != null)
         {
             mControllerProfile2.populateProfiles( mAppData.GetControllerProfilesConfig(),
-                mGlobalPrefs.GetControllerProfilesConfig(), "" );
+                mGlobalPrefs.GetControllerProfilesConfig(), mGlobalPrefs.getControllerProfileDefault(2) );
             mControllerProfile2.setSummary(mControllerProfile2.getCurrentValue());
         }
 
         if(mControllerProfile3 != null)
         {
             mControllerProfile3.populateProfiles( mAppData.GetControllerProfilesConfig(),
-                mGlobalPrefs.GetControllerProfilesConfig(), "" );
+                mGlobalPrefs.GetControllerProfilesConfig(), mGlobalPrefs.getControllerProfileDefault(3) );
             mControllerProfile3.setSummary(mControllerProfile3.getCurrentValue()); 
         }
         
         if(mControllerProfile4 != null)
         {
             mControllerProfile4.populateProfiles( mAppData.GetControllerProfilesConfig(),
-                mGlobalPrefs.GetControllerProfilesConfig(), "" );
+                mGlobalPrefs.GetControllerProfilesConfig(), mGlobalPrefs.getControllerProfileDefault(4) );
             mControllerProfile4.setSummary(mControllerProfile4.getCurrentValue());
         }
         
@@ -332,6 +332,9 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
             boolean enable3 = mGamePrefs.isControllerEnabled3 && mRomDetail.players > 2;
             boolean enable4 = mGamePrefs.isControllerEnabled4 && mRomDetail.players > 3;
             playerPref.setControllersEnabled( enable1, enable2, enable3, enable4 );
+            
+            // Set the initial value
+            playerPref.setValue( mGamePrefs.playerMap.serialize() );
         }
         
         mPrefs.registerOnSharedPreferenceChangeListener( this );
@@ -501,6 +504,9 @@ public class GamePrefsActivity extends AppCompatPreferenceActivity implements On
     {
         PlayerMapPreference playerPref = (PlayerMapPreference) findPreference( GamePrefs.PLAYER_MAP );
         playerPref.onDialogClosed(inputCode, hardwareId, which);
+        
+        if( playerPref.getValue().equals( mGlobalPrefs.getString( GamePrefs.PLAYER_MAP, "" ) ) )
+            playerPref.setValue( "" );
     }
 
     @Override

--- a/src/paulscode/android/mupen64plusae/preference/PlayerMapPreference.java
+++ b/src/paulscode/android/mupen64plusae/preference/PlayerMapPreference.java
@@ -45,7 +45,7 @@ import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 public class PlayerMapPreference extends DialogPreference implements
-        View.OnClickListener, OnCheckedChangeListener, OnPreferenceDialogListener
+        View.OnClickListener, OnCheckedChangeListener, OnPreferenceDialogListener, View.OnLongClickListener
 {
     public static final String STATE_PROMPT_INPUT_CODE_DIALOG = "STATE_PROMPT_INPUT_CODE_DIALOG";
     public static final String STATE_SELECTED_POPUP_INDEX = "STATE_SELECTED_POPUP_INDEX";
@@ -126,6 +126,35 @@ public class PlayerMapPreference extends DialogPreference implements
         checkBoxReminder.setChecked( prefs.getPlayerMapReminder() );
         checkBoxReminder.setOnCheckedChangeListener( this );
         updateViews();
+        
+        buttonPlayer1.setOnLongClickListener( this );
+        buttonPlayer2.setOnLongClickListener( this );
+        buttonPlayer3.setOnLongClickListener( this );
+        buttonPlayer4.setOnLongClickListener( this );
+    }
+    
+    @Override
+    public boolean onLongClick(View view)
+    {        
+        switch( view.getId() )
+        {
+            case R.id.btnPlayer1:
+                mMap.unmapPlayer( 1 );
+                break;
+            case R.id.btnPlayer2:
+                mMap.unmapPlayer( 2 );
+                break;
+            case R.id.btnPlayer3:
+                mMap.unmapPlayer( 3 );
+                break;
+            case R.id.btnPlayer4:
+                mMap.unmapPlayer( 4 );
+                break;
+            default: return false;
+        }
+        
+        updateViews();
+        return true;
     }
     
     @Override

--- a/src/paulscode/android/mupen64plusae/profile/ManageControllerProfilesActivity.java
+++ b/src/paulscode/android/mupen64plusae/profile/ManageControllerProfilesActivity.java
@@ -42,7 +42,7 @@ public class ManageControllerProfilesActivity extends ManageProfilesActivity
     @Override
     protected String getDefaultProfile()
     {
-        return mGlobalPrefs.getControllerProfileDefault();
+        return mGlobalPrefs.getControllerProfileDefault( 1 );
     }
     
     @Override


### PR DESCRIPTION
This pulls controller settings into the global settings area. I think this will make the controller setup more  intuitive. Per game settings can still override these settings, but now we won't have to set them up for each game every time we switch games. To revert the game settings to use the global settings, simply unmap all the players and specify the controllers settings as default. I don't think this is the best final solution, but I think it will work better than what is currently there until a better solution is found. Let me know of any issues.