### PR TITLE
Fixed text relocation errors on x86 Android M

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -15,7 +15,7 @@
 
     <uses-sdk
         android:minSdkVersion="15"
-        android:targetSdkVersion="22" />
+        android:targetSdkVersion="23" />
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />

--- a/jni/mupen64plus-core.mk
+++ b/jni/mupen64plus-core.mk
@@ -129,6 +129,46 @@ else ifeq ($(TARGET_ARCH_ABI), x86)
     LOCAL_CFLAGS += -DDYNAREC
     LOCAL_CFLAGS += -DNEW_DYNAREC=1
 
+    include $(BUILD_SHARED_LIBRARY)
+
+    # Build PIC-compliant library
+    SAVED_PATH := $(LOCAL_PATH)
+    SAVED_SHARED_LIBRARIES := $(LOCAL_SHARED_LIBRARIES)
+    SAVED_STATIC_LIBRARIES := $(LOCAL_STATIC_LIBRARIES)
+    SAVED_C_INCLUDES := $(LOCAL_C_INCLUDES)
+    SAVED_SRC_FILES := $(LOCAL_SRC_FILES)
+    SAVED_CFLAGS := $(LOCAL_CFLAGS)
+    SAVED_LDFLAGS := $(LOCAL_LDFLAGS)
+
+    include $(CLEAR_VARS)
+    LOCAL_PATH := $(SAVED_PATH)
+    LOCAL_SHARED_LIBRARIES := $(SAVED_SHARED_LIBRARIES)
+    LOCAL_STATIC_LIBRARIES := $(SAVED_STATIC_LIBRARIES)
+    LOCAL_C_INCLUDES := $(SAVED_C_INCLUDES)
+    LOCAL_MODULE := mupen64plus-core-pic
+
+    LOCAL_SRC_FILES := $(filter-out $(SRCDIR)/r4300/empty_dynarec.c \
+            $(SRCDIR)/r4300/new_dynarec/new_dynarec.c \
+            $(SRCDIR)/r4300/new_dynarec/x86/linkage_x86.asm \
+            , $(SAVED_SRC_FILES)) \
+        $(SRCDIR)/r4300/x86/assemble.c \
+        $(SRCDIR)/r4300/x86/gbc.c \
+        $(SRCDIR)/r4300/x86/gcop0.c \
+        $(SRCDIR)/r4300/x86/gcop1.c \
+        $(SRCDIR)/r4300/x86/gcop1_d.c \
+        $(SRCDIR)/r4300/x86/gcop1_l.c \
+        $(SRCDIR)/r4300/x86/gcop1_s.c \
+        $(SRCDIR)/r4300/x86/gcop1_w.c \
+        $(SRCDIR)/r4300/x86/gr4300.c \
+        $(SRCDIR)/r4300/x86/gregimm.c \
+        $(SRCDIR)/r4300/x86/gspecial.c \
+        $(SRCDIR)/r4300/x86/gtlb.c \
+        $(SRCDIR)/r4300/x86/regcache.c \
+        $(SRCDIR)/r4300/x86/rjump.c
+    LOCAL_CFLAGS := $(filter-out -DNEW_DYNAREC=1, $(SAVED_CFLAGS))  \
+        -ffast-math -mtune=atom -mssse3 -mfpmath=sse -fPIC
+    LOCAL_LDFLAGS := $(SAVED_LDFLAGS)
+
 else ifeq ($(TARGET_ARCH_ABI), mips)
     # Use for MIPS:
     #TODO: Possible to port dynarec from Daedalus? 

--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -38,6 +38,7 @@ import paulscode.android.mupen64plusae.util.Notifier;
 import paulscode.android.mupen64plusae.util.Utility;
 import android.content.DialogInterface;
 import android.media.AudioTrack;
+import android.os.Build;
 import android.os.Vibrator;
 import android.support.v4.app.FragmentManager;
 import android.support.v7.app.AppCompatActivity;
@@ -234,7 +235,7 @@ public class CoreInterface
         if( sCoreThread == null )
         {
             // Load the native libraries
-            NativeExports.loadLibraries( sAppData.libsDir );
+            NativeExports.loadLibraries( sAppData.libsDir, Build.VERSION.SDK_INT );
             
             // Start the core thread if not already running
             sCoreThread = new Thread( new Runnable()

--- a/src/paulscode/android/mupen64plusae/jni/NativeExports.java
+++ b/src/paulscode/android/mupen64plusae/jni/NativeExports.java
@@ -37,7 +37,7 @@ public class NativeExports
     
     // TODO: Add javadoc
     
-    public static native void loadLibraries( String libPath );
+    public static native void loadLibraries( String libPath, int androidSDK );
     
     public static native void unloadLibraries();
     

--- a/src/paulscode/android/mupen64plusae/persistent/AppData.java
+++ b/src/paulscode/android/mupen64plusae/persistent/AppData.java
@@ -241,7 +241,14 @@ public class AppData
         profilesDir = coreSharedDataDir + "/profiles";
         
         // Files
-        coreLib = libsDir + "/libmupen64plus-core.so";
+        String arch = System.getProperty("os.arch");
+        
+        // Check for x86, ignore 'arch64' or 'x86_64' for now
+        if( arch.equals( "i686" ) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M )
+            coreLib = libsDir + "/libmupen64plus-core-pic.so";
+        else
+            coreLib = libsDir + "/libmupen64plus-core.so";
+        
         rspLib = libsDir + "/libmupen64plus-rsp-hle.so";
         inputLib = libsDir + "/libmupen64plus-input-android.so";
         gln64_conf = coreSharedDataDir + "/gln64.conf";


### PR DESCRIPTION
Builds 2 shared objects for the core on x86 and switches between them at run-time depending on if Android M or later is detected. This fixes https://github.com/mupen64plus-ae/mupen64plus-ae/issues/540. Known Issue: Cannot resume a game when the PIC-compliant version of the core (old dynamic recompiler) is loaded.