### PR TITLE
Hack to temporarily fix issues with resuming on x86 Marshmallow.

### DIFF
--- a/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
+++ b/src/paulscode/android/mupen64plusae/jni/CoreInterface.java
@@ -22,6 +22,8 @@ package paulscode.android.mupen64plusae.jni;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import org.mupen64plusae.v3.alpha.R;
 
@@ -344,7 +346,24 @@ public class CoreInterface
                                 && saveToLoad != null)
                         {
                             removeOnStateCallbackListener( this );
-                            NativeExports.emuLoadFile( saveToLoad );
+                            
+                            if( sAppData.useX86PicLibrary )
+                            {
+                                // This is a hack to get "Resume" to work on x86 with the old
+                                // dynamic recompiler. Remove it once the new dynamic recompiler
+                                // works on x86 Marshmallow and later.
+                                new Timer("Resume Game").schedule(
+                                    new TimerTask()
+                                    {
+                                        @Override
+                                        public void run()
+                                        {
+                                            NativeExports.emuLoadFile( saveToLoad );
+                                        }
+                                    }, 1000);
+                            }
+                            else
+                                NativeExports.emuLoadFile( saveToLoad );
 
                             sActivity.runOnUiThread(new Runnable()
                             {

--- a/src/paulscode/android/mupen64plusae/persistent/AppData.java
+++ b/src/paulscode/android/mupen64plusae/persistent/AppData.java
@@ -127,6 +127,9 @@ public class AppData
     /** The directory for temporary files. Contents deleted on uninstall. */
     public final String tempDir;
     
+    /** True if using x86 on Marshmallow or later. */
+    public final boolean useX86PicLibrary;
+    
     /** The directory containing the native Mupen64Plus libraries. Contents deleted on uninstall, not accessible without root. */
     public final String libsDir;
     
@@ -244,7 +247,9 @@ public class AppData
         String arch = System.getProperty("os.arch");
         
         // Check for x86, ignore 'arch64' or 'x86_64' for now
-        if( arch.equals( "i686" ) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M )
+        useX86PicLibrary = arch.equals( "i686" ) && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+        
+        if (useX86PicLibrary)
             coreLib = libsDir + "/libmupen64plus-core-pic.so";
         else
             coreLib = libsDir + "/libmupen64plus-core.so";


### PR DESCRIPTION
I discovered that the old dynamic recompiler (for x86 on Marshmallow and newer) apparently needs a little bit of warm-up time before it can load saves. I tested this on my Nexus Player to determine how long of a warm-up was needed. It was somewhere between 250ms and 500ms, so I doubled that to 1000ms. It still may not work every time on everyone's setup, but I haven't been able to get it to fail. Hopefully, this is only a temporary fix until the new dynamic recompiler can support Marshmallow on x86.