### PR TITLE
Add a built-in profile for raphnet-tech GC/N64 to USB V3

### DIFF
--- a/app/src/main/assets/mupen64plus_data/profiles/controller.cfg
+++ b/app/src/main/assets/mupen64plus_data/profiles/controller.cfg
@@ -10,6 +10,12 @@ map=0:201,1:203,2:202,3:200,4:197,5:196,6:190,7:189,8:-30,9:-29,10:-23,11:-24,12
 deadzone=0
 sensitivitiy=100
 
+[USB N64 Adapter (raphnet V3)]
+comment=raphnet-tech GC/N64 and N64 to USB adapters, version 3
+map=19:-4,18:-3,17:-2,16:-1,7:96,6:97,4:99,11:102,10:103,9:104,8:105,0:106,2:108,3:109,1:110,
+deadzone=0
+sensitivity=100
+
 [Xbox]
 comment=Xbox360 and XInput-compatible PC controllers
 map=0:-31,1:-32,2:-33,3:-34,4:108,5:-23,6:99,7:96,8:-25,9:-26,10:-27,11:-28,12:103,13:102,16:-1,17:-2,18:-3,19:-4,32:97,

--- a/app/src/main/java/paulscode/android/mupen64plusae/task/ExtractAssetsTask.java
+++ b/app/src/main/java/paulscode/android/mupen64plusae/task/ExtractAssetsTask.java
@@ -89,7 +89,7 @@ public class ExtractAssetsTask extends AsyncTask<Void, String, List<ExtractAsset
             mAssetVersions.put("mupen64plus_data/gln64rom.conf", 1);
             mAssetVersions.put("mupen64plus_data/mupen64plus.ini", 4);
             mAssetVersions.put("mupen64plus_data/mupencheat.default", 1);
-            mAssetVersions.put("mupen64plus_data/profiles/controller.cfg", 1);
+            mAssetVersions.put("mupen64plus_data/profiles/controller.cfg", 2);
             mAssetVersions.put("mupen64plus_data/profiles/emulation.cfg", 3);
             mAssetVersions.put("mupen64plus_data/profiles/touchscreen.cfg", 2);
             mAssetVersions.put("mupen64plus_data/skins/touchscreen/JoshaGibs/analog-back.png", 1);


### PR DESCRIPTION
The raphnet-tech GC/N64 and N64 to USB adapters do not work
with the built-in profile, or at least not on all systems.

This patch adds a new built-in profile that works out of the box
with raphnet v3 adapters. Tested on a Samsum SM-J320V running android
7.1.1.