### PR TITLE
Add uploading build artifacts

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -26,3 +26,9 @@ jobs:
 
     - name: Build
       run: ./gradlew assemble
+
+    - name: Upload Build Artifact
+      uses: actions/upload-artifact@v2
+      with: 
+        name: apk
+        path: ${{ github.workspace }}/app/build/outputs/apk/*

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ Please visit [the official forum](http://www.paulscode.com/forum/index.php) for 
       height="80">](https://f-droid.org/packages/org.mupen64plusae.v3.alpha/)
 
 
-## Build Status
+## Nightly Builds
 
-|Build status: 	| [![Build Status][Build]][Actions] 
-|---------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|Download nightly builds from continuous integration: 	| [![Build Status][Build]][Actions] 
+|-------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
 
 [Actions]: https://github.com/mupen64plus-ae/mupen64plus-ae/actions
 [Build]: https://github.com/mupen64plus-ae/mupen64plus-ae/workflows/Mupen64Plus-AE/badge.svg


### PR DESCRIPTION
Hi there, this PR adds the following:
- I changed the Github Workflow so it will upload the Debug and Release APK's.
- Changes the README.md and points to Nightly Builds by clicking on "Mupen64Plus-AE - Passing" people can go to the CI/CD builds, and go to Artifacts to download the "apk" file.

There is a build running at this moment, when it completes you can see the "apk" file on the following Github page:
https://github.com/bladeoner/mupen64plus-ae/actions/runs/285936173

And the changes I made to the README.md you can see it under my branch:
https://github.com/bladeoner/mupen64plus-ae/tree/artifacts