### PR TITLE
Only upload debug artifacts

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -31,4 +31,4 @@ jobs:
       uses: actions/upload-artifact@v2
       with: 
         name: apk
-        path: ${{ github.workspace }}/app/build/outputs/apk/*
+        path: ${{ github.workspace }}/app/build/outputs/apk/debug/*


### PR DESCRIPTION
This will only upload the debug artifacts because the release artifacts won't work unsigned.