### PR TITLE
Fix - Fire TV Cube - crash on load

### DIFF
--- a/app/src/main/java/paulscode/android/mupen64plusae/game/GameActivity.java
+++ b/app/src/main/java/paulscode/android/mupen64plusae/game/GameActivity.java
@@ -203,11 +203,22 @@ public class GameActivity extends AppCompatActivity implements PromptConfirmList
     @Override
     protected void attachBaseContext(Context newBase) {
 
+        SharedPreferences preferences;
+        String localeCode;
 
-        SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences( newBase );
+        try
+        {
+            // Fire TV Cube (2nd generation) on Android 9 ( Fire OS 7.2.4.2 / PS7242/2216 ) crash here with a null exception when calling getDefaultSharedPreferences.
+            preferences = PreferenceManager.getDefaultSharedPreferences( newBase );
 
-        // Locale
-        String localeCode = preferences.getString( GlobalPrefs.KEY_LOCALE_OVERRIDE, DEFAULT_LOCALE_OVERRIDE );
+            // Locale
+            localeCode = preferences.getString( GlobalPrefs.KEY_LOCALE_OVERRIDE, DEFAULT_LOCALE_OVERRIDE );
+        }
+        catch(NullPointerException exception)
+        {
+            Log.i(TAG, "Null exception in attachBaseContext");
+            localeCode = LocaleContextWrapper.getLocalCode();
+        }
 
         if(TextUtils.isEmpty(localeCode))
         {

--- a/app/src/main/java/paulscode/android/mupen64plusae/game/GameActivity.java
+++ b/app/src/main/java/paulscode/android/mupen64plusae/game/GameActivity.java
@@ -203,13 +203,12 @@ public class GameActivity extends AppCompatActivity implements PromptConfirmList
     @Override
     protected void attachBaseContext(Context newBase) {
 
-        SharedPreferences preferences;
         String localeCode;
 
         try
         {
             // Fire TV Cube (2nd generation) on Android 9 ( Fire OS 7.2.4.2 / PS7242/2216 ) crash here with a null exception when calling getDefaultSharedPreferences.
-            preferences = PreferenceManager.getDefaultSharedPreferences( newBase );
+            SharedPreferences preferences = PreferenceManager.getDefaultSharedPreferences( newBase );
 
             // Locale
             localeCode = preferences.getString( GlobalPrefs.KEY_LOCALE_OVERRIDE, DEFAULT_LOCALE_OVERRIDE );


### PR DESCRIPTION
getDefaultSharedPreferences was causing a null exception in GameActivity.java.