### PR TITLE
AndroidManifest - File extension - Missing scheme

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -72,6 +72,7 @@
 
                 <data android:host="*" />
                 <data android:scheme="file" />
+                <data android:scheme="content" />
                 <data android:mimeType="*/*" />
                 <data android:pathPattern=".*\\.n64" />
                 <data android:pathPattern=".*\\.N64" />


### PR DESCRIPTION
Android 7.0 use the scheme "content" with the mimeType "*/*" without the line <data android:scheme="content" /> on Android 7.0 the mimeType was ignored and causing File Explorer like ES File Explorer to not allow to open file using Mupen.

With the change, we can now open n64, v64, z64, zip, 7z. 7zip from a File Explorer .i.e. ( ES File Explorer ).


From official Android 7.0 Changes:

For apps targeting Android 7.0, the Android framework enforces the StrictMode API policy that prohibits exposing file:// URIs outside your app. If an intent containing a file URI leaves your app, the app fails with a FileUriExposedException exception.

To share files between applications, you should send a content:// URI and grant a temporary access permission on the URI. The easiest way to grant this permission is by using the FileProvider class. For more information on permissions and sharing files, see Sharing Files.