### PR TITLE
Add Stale Workflow

### DIFF
--- a/.github/workflows/mark-pr-and-issue-as-stale.yml
+++ b/.github/workflows/mark-pr-and-issue-as-stale.yml
@@ -1,0 +1,24 @@
+name: Mark issues and pull requests as stale
+
+on:
+  schedule:
+  - cron: '0 1 * * Sun'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity.'
+        stale-pr-message: 'This pull request has been automatically marked as stale because it has not had recent activity.'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        days-before-issue-close: 5
+        days-before-pr-close: 5


### PR DESCRIPTION
@fzurita this change adds a Stale Workflow which will run every Sunday at 1 AM. It will check if there are PR's and/or Issues that haven't been updated for 60 days. The PR or Issue will be tagged and after 5 days automatically closed.