### PR TITLE
Address undersized stick range and floating point error

### DIFF
--- a/mupen64plus-input-android/src/plugin.cpp
+++ b/mupen64plus-input-android/src/plugin.cpp
@@ -324,14 +324,19 @@ extern "C" EXPORT void CALL InitiateControllers(CONTROL_INFO controlInfo)
 // Credit: MerryMage
 void simulateOctagon(double inputX, double inputY, int& outputX, int& outputY)
 {
-    //scale to {-84 ... +84}
-    double ax = inputX * maxAxis;
-    double ay = inputY * maxAxis;
+    deadzone = importedDeadzoneFromJava * maxAxis; //assuming deadzone from Java is something like 0.07 or 7% -- this needs to be converted to a control stick position count (so some fraction of maxAxis)
+        
+    //determine radius of outer deadzone
+    double maxRadiusOuterDeadzone = 2.0 / std::sqrt(2.0) * (69.0 / maxAxis * (maxAxis - deadzone) + deadzone);
+        
+    //scale to {-maxRadiusOuterDeadzone ... +maxRadiusOuterDeadzone}
+    double ax = inputX * maxRadiusOuterDeadzone;
+    double ay = inputY * maxRadiusOuterDeadzone;
 
     // Crop to a circle
     double len = std::sqrt(ax*ax+ay*ay);
-    if (len > maxAxis) {
-        len = maxAxis / len;
+    if (len > maxRadiusOuterDeadzone) {
+        len = maxRadiusOuterDeadzone / len;
         ax *= len;
         ay *= len;
     }
@@ -343,11 +348,19 @@ void simulateOctagon(double inputX, double inputY, int& outputX, int& outputY)
         double edgey = copysign(std::min(std::abs(edgex * slope), maxAxis / (1.0 / std::abs(slope) + 16.0 / 69.0)), ay);
         edgex = edgey / slope;
 
-        double scale = std::sqrt(edgex*edgex+edgey*edgey) / maxAxis;
+        double scale = std::sqrt(edgex*edgex+edgey*edgey) / maxRadiusOuterDeadzone;
         ax *= scale;
         ay *= scale;
     }
-
+    
+    //keep cardinal input within positive and negative bounds of maxAxis
+    if(std::abs(ax) > maxAxis) ax = copysign(maxAxis, ax);
+    if(std::abs(ay) > maxAxis) ay = copysign(maxAxis, ay);
+        
+    //prevent floating point precision error keeping values lower than they should be prior to truncation
+    ax = copysign(std::abs(ax) + 1e-03, ax);
+    ay = copysign(std::abs(ay) + 1e-03, ay);
+        
     outputX = static_cast<int>(ax);
     outputY = static_cast<int>(ay);
 }


### PR DESCRIPTION
Currently, the control stick will not be able to produce values between (60, 60) or (61,61) and (68, 68), inclusive. This is due to the undersized scaling of the range when considering the maximum cardinal value as the maximum radius of the circle. Therefore, the diagonal (and the deadzone) also needs to be used in the initial scaling in order to ensure every value of the octagon is covered. Consequently, this value is now greater than the maximum cardinal value and requires a clamp after the octagon simulation to stop the excessive values.

After encountering issues with the diagonal not reaching its full value, the decision was made to add a small epsilon at the end just before casting to an integer to allow the diagonal to reach its full value. Same issue can happen for the deadzone. This method was chosen over rounding up because that would only reduce input and mean a small deadzone would be exited earlier than desired.
