### PR TITLE
Fix release build: add wildcard dontwarn for zstd

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -55,9 +55,7 @@
 -dontwarn org.ietf.jgss.GSSName
 -dontwarn org.ietf.jgss.Oid
 -dontwarn com.google.errorprone.annotations.CanIgnoreReturnValue
--dontwarn com.github.luben.zstd.BufferPool
--dontwarn com.github.luben.zstd.ZstdInputStream
--dontwarn com.github.luben.zstd.ZstdOutputStream
+-dontwarn com.github.luben.zstd.**
 -dontwarn org.brotli.dec.BrotliInputStream
 -dontwarn org.objectweb.asm.AnnotationVisitor
 -dontwarn org.objectweb.asm.Attribute


### PR DESCRIPTION
Hi @fzurita, small follow-up to #1242. While building a release APK for testing, R8 minification fails with:

```
Missing class com.github.luben.zstd.Zstd (referenced from: void org.apache.commons.compress.compressors.zstandard.ZstdConstants.<clinit>())
```

The existing rules already exclude `BufferPool`, `ZstdInputStream`, and `ZstdOutputStream` but miss the main `Zstd` class. Replacing them with a wildcard (`com.github.luben.zstd.**`) covers all of them.

With this fix, `./gradlew assembleRelease` succeeds and the resulting APK runs fine on Chromecast with Google TV (Android 12) — performance is noticeably better than the debug build, as expected.

Re: your concern about `MANAGE_EXTERNAL_STORAGE` and Play Store approval — totally understand. If you'd like, I'm happy to follow up with another PR that gates that permission behind an Android TV check (`AppData.isAndroidTv`) so it only gets requested on TV devices where SAF is actually broken. That would keep the phone/tablet flow unchanged and limit the scope of the permission justification.